### PR TITLE
Fix analyse_point_source_scans

### DIFF
--- a/katsdpscripts/reduction/analyse_point_source_scans.py
+++ b/katsdpscripts/reduction/analyse_point_source_scans.py
@@ -283,6 +283,11 @@ def analyse_point_source_scans(filename, opts):
     fh.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
     logger.addHandler(fh)
 
+    # Produce canonical version of baseline string (remove duplicate antennas)
+    baseline_ants = opts.baseline.split(',')
+    if len(baseline_ants) == 2 and baseline_ants[0] == baseline_ants[1]:
+        opts.baseline = baseline_ants[0]
+
     # Load old CSV file used to select compound scans from dataset
     keep_scans = keep_datasets = None
     if opts.keepfilename:
@@ -302,8 +307,8 @@ def analyse_point_source_scans(filename, opts):
         opts.batch = True
         logger.debug("Loaded CSV file '%s' containing %d dataset(s) and %d compscan(s) for antenna '%s'" %
                      (opts.keepfilename, len(keep_datasets), len(keep_scans), ant_name))
-        # Ensure we are using antenna found in CSV file (assume ant name = "ant" + number)
-        csv_baseline = 'A%sA%s' % (ant_name[3:], ant_name[3:])
+        # Ensure we are using antenna found in CSV file (this assumes single dish setup for now)
+        csv_baseline = ant_name
         if opts.baseline != 'sd' and opts.baseline != csv_baseline:
             logger.warn("Requested baseline '%s' does not match baseline '%s' in CSV file '%s'" %
                         (opts.baseline, csv_baseline, opts.keepfilename))

--- a/reduction/analyse_point_source_scans.py
+++ b/reduction/analyse_point_source_scans.py
@@ -13,7 +13,8 @@ parser = optparse.OptionParser(usage="%prog [opts] <HDF5 file>",
                                            "from the compound scans in it. It runs interactively by default, "
                                            "which allows the user to inspect results and discard bad scans.")
 parser.add_option("-a", "--baseline", default='sd',
-                  help="Baseline to load (e.g. 'A1A1' for antenna 1), default is first single-dish baseline in file")
+                  help="Baseline to load (e.g. 'ant1' for antenna 1 or 'ant1,ant2' for 1-2 baseline), "
+                       "default is first single-dish baseline in file")
 parser.add_option("-b", "--batch", action="store_true",
                   help="Flag to do processing in batch mode without user interaction")
 parser.add_option("-f", "--freq-chans",


### PR DESCRIPTION
Fix exceptions during interactive use of the script due to recent refactoring.
Suppress errors during reduction and skip the offending compscans instead.
Fix code that depended on antenna names being 'antN'.

Reviewers: @mauch @mattieudv 
