### PR TITLE
Add obs report

### DIFF
--- a/obs_report/obs_report.py
+++ b/obs_report/obs_report.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import katfile
+import katdal as katfile
 import matplotlib as mpl; mpl.use('Agg')
 import matplotlib.pyplot as plt
 import numpy as np


### PR DESCRIPTION
Addition of the observation reporting script from its previous home in svn. I have tried to retain the commit history of the script and clean things up a little bit. 
The script was initially created in svnScience (called obs_report.py) and then at some stage was moved over to svnDS (also called obs_report.py there), however changes were made to the script in both locations in parallel. I have included the revision history of both of these versions and renamed them 'obs_report_svnScience.py' and 'obs_report_svnDS.py' to indicate where they originated. 
At some point a new script 'new_obs_report.py' was created in svnDS from the obs_report_svnDS.py script. 'new_obs_report.py' is the canonical version of the script so I have renamed this to the more simple 'obs_report.py' and removed the old scripts (though their revision histories should still be available).
@ludwigschwardt : There is no need to check the content of the scripts themselves, just make sure I haven't broken anything in the migration from svn.
