### PR TITLE
Make the offset target name unique 

### DIFF
--- a/RTS/2.7-Pointing/offset_test_scan.py
+++ b/RTS/2.7-Pointing/offset_test_scan.py
@@ -54,7 +54,7 @@ opts, args = parser.parse_args()
 
 if opts.quick:
     opts.dump_rate = 2.0
-uniquename = 0.25
+uniquename = 0
 with verify_and_connect(opts) as kat:
     if not kat.dry_run and kat.ants.req.mode('STOP') :
         user_logger.info("Setting Antenna Mode to 'STOP', Powering on Antenna Drives.")


### PR DESCRIPTION
This is the fix to make the offset target name unique so that katdal does not crash out for no good reason

Can you check the change and merge the code 
@sratcliffe @ludwigschwardt 
