### PR TITLE
TLE Catalogue Bug in Linearity_scan.py

### DIFF
--- a/RTS/2.6-Linearity/linearity_scan.py
+++ b/RTS/2.6-Linearity/linearity_scan.py
@@ -36,7 +36,6 @@ if len(args) == 0:
     raise ValueError("Please specify at least one target argument via name ('Cygnus A'), "
                      "description ('azel, 20, 30') or catalogue file name ('sources.csv')")
 
-args_target_obj = None
 # Check options and build KAT configuration, connecting to proxies and devices
 with verify_and_connect(opts) as kat:
     args_target_list =[]
@@ -50,7 +49,7 @@ with verify_and_connect(opts) as kat:
     
     try:
         observation_sources.add_tle(file(args[0]))
-    except :#IOError or ValueError : # If the file failed to load assume it is a target string
+    except (IOError, ValueError):#IOError or ValueError : # If the file failed to load assume it is a target string
         args_target_obj = collect_targets(kat,args)
         observation_sources.add(args_target_obj)
             


### PR DESCRIPTION
Hi @rubyvanrooyen 

This affects you and your use of the script. This bug was exposed when we started passing a catalogue file to script instead of a name argument to the script

This is a fix to sort out a problem when the file given to the script does not contain TLE's causing the script to crash out. the fix involves checking the first file to see if it contains TLE's and then collecting the targets if not are found
