### PR TITLE
Fix typo in skyloadcal.py  script

### DIFF
--- a/RTS/2.2-T_sys_T_nd/skyloadcal.py
+++ b/RTS/2.2-T_sys_T_nd/skyloadcal.py
@@ -80,7 +80,7 @@ with verify_and_connect(opts) as kat:
             katpoint.construct_radec_target(wrap_angle(moon.azel()[0] + np.radians(10) ),moon.azel()[1] )
             off1.antenna = antenna
             off1.name = 'off'
-            off2 = katpoint.construct_azel_target(wrap_angle(moon.azel()[0] - np.radians(10) ),moon.azel()[1] )
+            off2 = katpoint.construct_radec_target(wrap_angle(moon.azel()[0] - np.radians(10) ),moon.azel()[1] )
             off2.antenna =  antenna 
             off2.name = 'off'
             sources = katpoint.Catalogue(add_specials=False)


### PR DESCRIPTION
@lmagnus 
Fix typo that made a azel target instead of a radec target that caused the script to crash if the bad sky spot was colder.
