### PR TITLE
Residual pointing offset

### DIFF
--- a/RTS/2.7-Pointing/residual_pointing_offset.py
+++ b/RTS/2.7-Pointing/residual_pointing_offset.py
@@ -148,6 +148,7 @@ for filename in args:
 
     text1 = referencemetrics(ant,az,el,measured_delta_az, measured_delta_el,delta_azimuth_std,delta_elevation_std,opts.num_samples_limit)
     text += text1
+    text.append("")
 
 #print new_model.description
 


### PR DESCRIPTION
This fixed a bug in the Residual pointing offset code that did not take the pointing model into account when working out offsets.

The output as adjusted  to handle multiple files in a sensible manner .

@tony2heads @lmagnus 
