### PR TITLE
Messy Hack to get the script to ignore noise diodes if they are not present 

### DIFF
--- a/katsdpscripts/reduction/analyse_point_source_scans.py
+++ b/katsdpscripts/reduction/analyse_point_source_scans.py
@@ -143,7 +143,10 @@ def reduce_compscan_with_uncertainty(dataset, compscan_index=0, mc_iterations=1,
                                                                        ' '.join(compscan_key(compscan)),))
     # Build data set containing a single compound scan at a time (make copy, as reduction modifies it)
     scan_dataset.compscans = [compscan]
-    compscan_dataset = scan_dataset.select(flagkeep='~nd_on', copy=True)
+    if not dataset.nd_h_model is None and not dataset.nd_v_model is None : # If there are no noisediode models assume that there are no noisediodes
+        compscan_dataset = scan_dataset.select(flagkeep='~nd_on', copy=True)
+    else :
+        compscan_dataset = dataset.select(labelkeep='scan', copy=True)
     cal_dataset = extract_cal_dataset(dataset)
     # Do first reduction run
     main_compscan = compscan_dataset.compscans[0]


### PR DESCRIPTION
This commit is a Messy Hack to get the script to ignore noise diodes if they are not present.
The script uses the logic : 
  If there are no noise diode  models assume that there are no noise diodes .
There is nothing that can go wrong with this over-generalized logic.
If something goes wrong, like if you have not put noise diode into the system then you will have the script fitting peaks to the noise diodes and failing (Hopefully )
@ludwigschwardt said it was ok :8ball:  
