### PR TITLE
Add  attenuation setting to Strong sources  script

### DIFF
--- a/RTS/2.8-Strong_Sources/strong_source_track.py
+++ b/RTS/2.8-Strong_Sources/strong_source_track.py
@@ -122,9 +122,11 @@ with verify_and_connect(opts) as kat:
                 if endobs : break
                 for ant in kat.ants:
                     if attenuation== -1 :
-                        attenuation = attenuation_old[ant.name+'h']                   
+                        attenuation = attenuation_old[ant.name+'v']                   
                     ant.req.dig_attenuation('v', attenuation, timeout=30)
                     user_logger.info("%s v pol , attenuation set to = %f"%(ant.name,ant.sensor.dig_l_band_rfcu_vpol_attenuation.get_value() ))
+                    if attenuation== -1 :
+                        attenuation = attenuation_old[ant.name+'h']                   
                     ant.req.dig_attenuation('h', attenuation, timeout=30)
                     user_logger.info("%s h pol , attenuation set to = %f"%(ant.name,ant.sensor.dig_l_band_rfcu_hpol_attenuation.get_value() ))
                     
@@ -151,9 +153,10 @@ with verify_and_connect(opts) as kat:
                     if endobs : break
                 if endobs : break
     for ant in kat.ants:
-        attenuation = attenuation_old[ant.name+'h']                   
+        attenuation = attenuation_old[ant.name+'v']                   
         ant.req.dig_attenuation('v', attenuation, timeout=30)
         user_logger.info("%s v pol , attenuation set to = %f"%(ant.name,ant.sensor.dig_l_band_rfcu_vpol_attenuation.get_value() ))
+        attenuation = attenuation_old[ant.name+'h']                   
         ant.req.dig_attenuation('h', attenuation, timeout=30)
         user_logger.info("%s h pol , attenuation set to = %f"%(ant.name,ant.sensor.dig_l_band_rfcu_hpol_attenuation.get_value() ))
                     


### PR DESCRIPTION
I have added attenuation setting to the strong_sources script.
It will set the attenuation to 39 when looking at the strong source .
When the observing other sources it will use the original attenuation .
@ludwigschwardt and @mauch  could you have a quick look through this script and see that it meets the requirements in MRTS-312
