### PR TITLE
fix array size problem if antennas have different activitys

### DIFF
--- a/RTS/2.1-Tipping_Curve/red_tipping_curve.py
+++ b/RTS/2.1-Tipping_Curve/red_tipping_curve.py
@@ -605,11 +605,12 @@ for ant in h5.ants:
 
     freq_list = np.zeros((len(chunks)))
     for j,chunk in enumerate(chunks):freq_list[j] = h5.channel_freqs[chunk].mean()/1e6
-    tsys = np.zeros((len(h5.scan_indices),len(chunks),5 ))#*np.NaN
-    tant = np.zeros((len(h5.scan_indices),len(chunks),5 ))#*np.NaN
     print "Selecting channel data to form %f MHz Channels"%(channel_bw)
     d = load_cal(filename, "%s" % (ant.name,), nd_models, chunks,channel_mask=channel_mask,n_chan=n_chans,channel_range=freq_chans)
     for j in xrange(len(d.freqs)):freq_list[j] = d.freqs[j]
+
+    tsys = np.zeros((len(d.scans),len(freq_list),5 ))#*np.NaN
+    tant = np.zeros((len(d.scans),len(freq_list),5 ))#*np.NaN
 
     SpillOver = Spill_Temp(filename=spill_over_models)
     receiver = Rec_Temp(receiver_model_H, receiver_model_V)


### PR DESCRIPTION
@mauch 
This fixes the problem where one antenna has a different number of scans than the other and the results away would be the wrong size.

This is bug was found in this file 
/var/kat/archive/data/RTS/telescope_products/2016/02/25/1456426853.h5
