### PR TITLE
Fix baseline indexing bug in baseline reduction

### DIFF
--- a/reduction/baseline_cal_reduction.py
+++ b/reduction/baseline_cal_reduction.py
@@ -69,7 +69,8 @@ data.select(channels=chan_range, corrprods='cross', pol=active_pol)
 if opts.ants is not None:
     data.select(ants=opts.ants, reset='')
 ref_ant_ind = [ant.name for ant in data.ants].index(data.ref_ant)
-baseline_inds = [(data.inputs.index(inpA), data.inputs.index(inpB)) for inpA, inpB in data.corr_products]
+inputs = [ant.name + active_pol for ant in data.ants]
+baseline_inds = [(inputs.index(inpA), inputs.index(inpB)) for inpA, inpB in data.corr_products]
 baseline_names = [('%s - %s' % (inpA[:-1], inpB[:-1])) for inpA, inpB in data.corr_products]
 num_bls = data.shape[2]
 if num_bls == 0:


### PR DESCRIPTION
The script made an assumption that katdal data.ants and data.inputs line up.
This is not guaranteed, however (in general they are not even the same size).
Rather base the input list directly on data.ants. This makes the script work
for more than one baseline (and validates undoing the delay tracking).
