### PR TITLE
Fix plots offset pointing

### DIFF
--- a/RTS/2.7-Pointing/residual_pointing_offset.py
+++ b/RTS/2.7-Pointing/residual_pointing_offset.py
@@ -328,12 +328,20 @@ def plots_cuhistogram(data,title,fit=stats.rayleigh ,fig=None):
     params = fit.fit(data['rms'],floc=0.0 ) # force the distrobution to start at 0.0  
     cdf = lambda x: fit.cdf(x, *params)
     y = cdf(x)
+    ppf = lambda x: fit.ppf(x, *params)
+    
     plt.plot(x,y, label=r"Fitted a '%s' distribution with a mean = %3.3f "%(fit.name,params[1]*np.sqrt(np.pi/2.)))
     plt.axhline(y=0.95,color='r',lw=1,ls='--')
     plt.axhline(y=0.90,color='k',lw=1,ls='--')
     plt.legend(numpoints=1,loc='upper right')
-    print "%s Fitted a '%s' distribution with mean = %3.3f "%(title,fit.name,params[1]*np.sqrt(np.pi/2.))
-    return fig
+    text = []
+    text.append("===========================")
+    text.append("%s Cumulative distribution %3.1f %c of samples are within %3.3f "%(title,95,'%',ppf(0.95) ) )
+    text.append("%s Cumulative distribution %3.1f %c of samples are within %3.3f "%(title,90,'%',ppf(0.90) ) )
+    text.append("%s Fitted a '%s' distribution with mean = %3.3f "%(title,fit.name,params[1]*np.sqrt(np.pi/2.)) )
+    text.append("===========================")
+    for line in text : print line
+    return fig , text 
 
     
 def write_text(textString):
@@ -483,7 +491,8 @@ if not opts.no_plot :
     if len(output_data['condition']) > 0 :
         fig = plt.figure()
         suptitle = '%s offset-pointing accuracy with kde  (all sources )' %ant.name.upper()
-        fig =  plots_cuhistogram(output_data,suptitle)
+        fig ,text=  plots_cuhistogram(output_data,suptitle)
+        for line in text : textString.insert(0,line)        
         fig.savefig(pp,format='pdf')
         plt.close(fig)
 
@@ -496,7 +505,8 @@ if not opts.no_plot :
 
     if ((output_data['condition'] == 2) + (output_data['condition'] == 3)).sum() > 0 :
         suptitle = '%s offset-pointing accuracy with kde (normal conditions)' %ant.name.upper()
-        fig = plots_cuhistogram(output_data[ (output_data['condition'] == 2) + (output_data['condition'] == 3)],suptitle)
+        fig ,text= plots_cuhistogram(output_data[ (output_data['condition'] == 2) + (output_data['condition'] == 3)],suptitle)
+        for line in text : textString.insert(0,line)        
         fig.savefig(pp,format='pdf')
         plt.close(fig)
 
@@ -508,7 +518,8 @@ if not opts.no_plot :
 
     if ((output_data['condition'] == 1) + (output_data['condition'] == 0)).sum() > 0 :
         suptitle = '%s offset-pointing accuracy with kde (optimal conditions)' %ant.name.upper()
-        fig = plots_cuhistogram(output_data[(output_data['condition'] == 1) + (output_data['condition'] == 0)],suptitle)
+        fig, text = plots_cuhistogram(output_data[(output_data['condition'] == 1) + (output_data['condition'] == 0)],suptitle)
+        for line in text : textString.insert(0,line)        
         fig.savefig(pp,format='pdf')
         plt.close(fig)
 


### PR DESCRIPTION
This file does have a histogram with a kernel density estimation over plotted with the addition of a fitted 'rayleigh' distribution. This is done using the seaborn package . a couple of smaller bugs have also been addressed 
There have been some other changes .
Only sources with a source strength > 7 (correlator units ) are plotted .
A pointing model is fitted to the < 7 (correlator units ) and this model is used to correct for the non offset terms in the pointing model. I noticed this was necessary when looking at the scatter vs elevation plots and released that coloration errors would cause an increase towards higher elevations and other affects would also effect the telescope.
I think that the small number of optimal measurements are causing the large error seen in the optimal results vs the nominal ones.
