### PR TITLE
Removing blanck line at the start of the file

### DIFF
--- a/AR1/UHF_scan.py
+++ b/AR1/UHF_scan.py
@@ -10,6 +10,18 @@ from katcorelib import standard_script_options, verify_and_connect, collect_targ
 import scpi as SCPI
 import numpy as np
  
+ 
+
+
+class Temp():
+    def __init__(self,):
+        pass
+    def __enter__(self):
+        pass
+    def __exit__(self, type, value, traceback):
+        pass
+
+
 # Set up standard script options
 parser = standard_script_options(usage="%prog [options] <'target/catalogue'> [<'target/catalogue'> ...]",
                                  description='Track one or more sources for a specified time. then change the frequency of'
@@ -109,7 +121,7 @@ with verify_and_connect(opts) as kat:
                 sigconn=SCPI.SCPI(siggen_ip,siggen_port)
                 testcon = sigconn.testConnect()
             else : 
-                sigconn = file('tempsock.tmp')
+                sigconn = Temp()
                 testcon = False
             
             with sigconn as sig :


### PR DESCRIPTION
, so that when the file is run os.execl it does not get a 'OSError: [Errno 8] Exec format error'
