### PR TITLE
Wait longer for gain solutions

### DIFF
--- a/AR1/observations/bf_phaseup_AR1.py
+++ b/AR1/observations/bf_phaseup_AR1.py
@@ -147,7 +147,7 @@ with verify_and_connect(opts) as kat:
             # Attempt to jiggle cal pipeline to drop its gains
             session.ants.req.target('')
             user_logger.info("Waiting for gains to materialise in cal pipeline")
-            time.sleep(10)
+            time.sleep(30)
             telstate = get_telstate(session.data, kat.sub)
             delays = get_delaycal_solutions(telstate)
             bp_gains = get_bpcal_solutions(telstate)


### PR DESCRIPTION
With 8 antennas the bfcal gains take up to 18 seconds to produce in the
cal pipeline (mostly due to B solver), so wait a bit longer. This probably
needs to be revisited for 16 antennas.
