### PR TITLE
Store script arguments in telstate

### DIFF
--- a/AR1/observations/beamform_AR1.py
+++ b/AR1/observations/beamform_AR1.py
@@ -100,7 +100,7 @@ with verify_and_connect(opts) as kat:
     telstate = get_telstate(kat.data, kat.sub)
     script_args = vars(opts)
     script_args['targets'] = args
-    telstate.add('obs_script_arguments', script_args, immutable=True)
+    telstate.add('obs_script_arguments', script_args)
 
     # Start capture session
     with start_session(kat, **vars(opts)) as session:


### PR DESCRIPTION
This is a furtive start to communicating directly with telstate from the
observation script. Its immediate purpose is to allow selection of the
beamformer backend from the script, since all backends share a common graph.

The current obs_params only gets set after capture_init, by which time the
SDP pipeline is constructed and ready for data. In order to influence its
construction, script arguments have to be passed in before capture_init and
the new obs_script_arguments item does exactly that.

An alternative is to delay capture_init until just before capture_start
in the session. This might still happen as well. The chosen path allows
the future untangling of obs_params into the pure obs_script_arguments
(i.e. requested settings) and the rest.

Also improve the response to setting the beam passband.
