### PR TITLE
Support new KATCP style of sensor access

### DIFF
--- a/observation/auto_attenuate.py
+++ b/observation/auto_attenuate.py
@@ -212,8 +212,8 @@ with verify_and_connect(opts) as kat:
                 user_logger.error("dbe7 mode is '%s' and not in the list of valid modes. Could not set appropriate gain." % (dbe_mode))
 
             # Populate lookup table that maps ant+pol to DBE input
-            for dbe_input_sensor in [sensor for sensor in vars(selected_dbe.sensor) if sensor.startswith('input_mappings_')]:
-                ant_pol = getattr(selected_dbe.sensor, dbe_input_sensor).get_value()
+            for dbe_input_sensor in [sensor for sensor in selected_dbe.sensor if sensor.startswith('input_mappings_')]:
+                ant_pol = selected_dbe.sensor[dbe_input_sensor].get_value()
                 connected_antpols[ant_pol] = dbe_input_sensor[15:]
 
             # Create device array of antennas, based on specification string

--- a/observation/beamform.py
+++ b/observation/beamform.py
@@ -30,9 +30,9 @@ def select_ant(cbf, ant, bf='bf0'):
 
 def get_weights(cbf):
     weights = {}
-    for sensor_name in vars(cbf.sensor):
+    for sensor_name in cbf.sensor:
         if sensor_name.endswith('_gain_correction_per_channel'):
-            sensor = getattr(cbf.sensor, sensor_name)
+            sensor = cbf.sensor[sensor_name]
             weights[sensor_name.split('_')[1]] = sensor.get_value()
     return weights
 

--- a/observation/beamform_dualpol.py
+++ b/observation/beamform_dualpol.py
@@ -73,11 +73,13 @@ def select_ant(cbf, input, bf='bf0'):
 def get_weights(cbf):
     """Retrieve the latest gain corrections and their corresponding update times."""
     weights, times = {}, {}
-    for sensor_name in vars(cbf.sensor):
+    for sensor_name in cbf.sensor:
         if sensor_name.endswith('_gain_correction_per_channel'):
-            sensor = getattr(cbf.sensor, sensor_name)
-            weights[sensor_name.split('_')[1]] = sensor.get_value()
-            times[sensor_name.split('_')[1]] = sensor.value_seconds
+            sensor = cbf.sensor[sensor_name]
+            input_name = sensor_name.split('_')[1]
+            reading = sensor.get_reading()
+            weights[input_name] = reading.value
+            times[input_name] = reading.timestamp
     return weights, times
 
 

--- a/observation/f_engine_phased_beamform_dualpol.py
+++ b/observation/f_engine_phased_beamform_dualpol.py
@@ -73,11 +73,13 @@ def select_ant(cbf, input, bf='bf0'):
 def get_weights(cbf):
     """Retrieve the latest gain corrections and their corresponding update times."""
     weights, times = {}, {}
-    for sensor_name in vars(cbf.sensor):
+    for sensor_name in cbf.sensor:
         if sensor_name.endswith('_gain_correction_per_channel'):
-            sensor = getattr(cbf.sensor, sensor_name)
-            weights[sensor_name.split('_')[1]] = sensor.get_value()
-            times[sensor_name.split('_')[1]] = sensor.value_seconds
+            sensor = cbf.sensor[sensor_name]
+            input_name = sensor_name.split('_')[1]
+            reading = sensor.get_reading()
+            weights[input_name] = reading.value
+            times[input_name] = reading.timestamp
     return weights, times
 
 


### PR DESCRIPTION
The KATCP client.sensor object is now an AttrMappingProxy with different
semantics to the old one. Iteration is simpler, while get_value() is replaced
by get_reading() when a timestamp is also required.

This fixes the KAT-7 era scripts for use with AR1 systems (as in use by
KAT-7 too).
