### PR TITLE
Use telstate to find correct cal pol ordering

### DIFF
--- a/AR1/observations/bf_phaseup_AR1.py
+++ b/AR1/observations/bf_phaseup_AR1.py
@@ -29,6 +29,8 @@ def get_cbf_inputs(data):
 
 def get_cal_inputs(telstate):
     """Input labels associated with calibration products."""
+    if 'cal_antlist' not in telstate or 'cal_pol_ordering' not in telstate:
+        return []
     ants = telstate['cal_antlist']
     polprods = telstate['cal_pol_ordering']
     pols = [prod[0] for prod in polprods if prod[0] == prod[1]]
@@ -45,27 +47,27 @@ def get_telstate(data, sub):
 
 def get_delaycal_solutions(telstate):
     """Retrieve delay calibration solutions from telescope state."""
-    if 'cal_antlist' not in telstate or 'cal_product_K' not in telstate:
-        return {}
     inputs = get_cal_inputs(telstate)
+    if not inputs or 'cal_product_K' not in telstate:
+        return {}
     solutions = telstate['cal_product_K']
     return dict(zip(inputs, solutions.real.flat))
 
 
 def get_bpcal_solutions(telstate):
     """Retrieve bandpass calibration solutions from telescope state."""
-    if 'cal_antlist' not in telstate or 'cal_product_B' not in telstate:
-        return {}
     inputs = get_cal_inputs(telstate)
+    if not inputs or 'cal_product_B' not in telstate:
+        return {}
     solutions = telstate['cal_product_B']
     return dict(zip(inputs, solutions.reshape((solutions.shape[0], -1)).T))
 
 
 def get_gaincal_solutions(telstate):
     """Retrieve gain calibration solutions from telescope state."""
-    if 'cal_antlist' not in telstate or 'cal_product_G' not in telstate:
-        return {}
     inputs = get_cal_inputs(telstate)
+    if not inputs or 'cal_product_G' not in telstate:
+        return {}
     solutions = telstate['cal_product_G']
     return dict(zip(inputs, solutions.flat))
 


### PR DESCRIPTION
The polarisation order in the pipeline calibration products were assumed
to be 'h' and then 'v' but this has recently changed, causing phase-up
failures. In fact, the correct order has always been represented by the
'cal_pol_ordering' telstate item, so use that instead. This should also
cater for possible future single-polarisation operations.

This addresses JIRA ticket [MKAIV-493](https://skaafrica.atlassian.net/browse/MKAIV-493).