### PR TITLE
Update AR1_obs_report_template.ipynb

### DIFF
--- a/AR1/obs_report/AR1_obs_report_template.ipynb
+++ b/AR1/obs_report/AR1_obs_report_template.ipynb
@@ -212,8 +212,6 @@
     "\n",
     "    figure(figsize=(15,30))\n",
     "    imshow(hstack(scan_phase),aspect='auto',origin='lower',extent=[x1,x2,y1,y2])\n",
-    "    for label in labels:\n",
-    "        label.set_rotation('vertical')\n",
     "    plt.xlabel('Time (s), since %s' % (katpoint.Timestamp(data.start_time).local(),))\n",
     "    plt.yticks(np.arange(num_chans // 2, num_bls * num_chans, num_chans), baseline_names)\n",
     "    for yval in range(0, num_bls * num_chans, num_chans):\n",


### PR DESCRIPTION
This patch fixes a problem in the obs reporting when there are scans with only 1 dump ... the scape plot_segments routine fails. Have used the raw imshow instead