### PR TITLE
Avoid numpy 1.12.0 as it fails to build extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python
-from setuptools import find_packages
+from setuptools import dist, find_packages
+
+# Avoid NumPy 1.12.0 which broke f2py and cannot build gsm extension
+good_numpy = 'numpy !=1.12.0b1, !=1.12.0rc1, !=1.12.0rc2, !=1.12.0'
+# Ensure we have NumPy before we start as it is needed before we call setup()
+# If not installed system-wide it will be downloaded into the local .eggs dir
+dist.Distribution(dict(setup_requires=good_numpy))
+
 from numpy.distutils.core import setup, Extension
 
 
@@ -31,6 +38,6 @@ setup(name="katsdpscripts",
           Extension(name='gsm', sources=['RTS/gsm/gsm.f'],
                     extra_f77_compile_args=['-std=legacy -ffixed-line-length-0'])],
       package_data={'': ['RTS/gsm/gsm.f']},
-      setup_requires=['katversion'],
+      setup_requires=['katversion', good_numpy],
       use_katversion=True,
       install_requires=['numpy', 'katpoint', 'katcp', 'scikits.fitting'])


### PR DESCRIPTION
The gsm extension module fails to build with numpy 1.12.0 as there was a regression in f2py (see numpy issue [#8479](https://github.com/numpy/numpy/issues/8479) and subsequent fix in PR [#8494](https://github.com/numpy/numpy/pull/8494)). F2py now fails to dimension arrays with parameter-based shapes. The end result is that the package fails to install.

The proposed solution is to add a known good numpy as a setup (and "pre-setup") require. If your system already has a proper numpy it is used; otherwise numpy 1.11.3 or a future version will be
downloaded locally for the extension build (and then discarded).
