### PR TITLE
Horizon check for interferometric pointing scan

### DIFF
--- a/AR1/observations/interferometric_pointing.py
+++ b/AR1/observations/interferometric_pointing.py
@@ -65,7 +65,9 @@ with verify_and_connect(opts) as kat:
                 for target in observation_sources.iterfilter(el_limit_deg=opts.horizon):
                     # Check if all offset pointings in compound scan will be up
                     compound_steps = 1 + 2 * (opts.number_of_steps // 2)
-                    compound_duration = compound_steps * opts.track_duration
+                    # Add some extra time for slews between pointings
+                    step_duration = opts.track_duration + 4.
+                    compound_duration = compound_steps * step_duration
                     if not session.target_visible(target, duration=compound_duration):
                         continue
                     session.label('interferometric_pointing')


### PR DESCRIPTION
This PR is to let the interferometric pointing script completely skip targets that session detects are setting, and get a review going. The reasoning is described in:

https://skaafrica.atlassian.net/browse/APS-16

we can run this branch to give it a try before merging if desired. This issue does reveal a corner case that we will have to take into account in the pointing model adjustment function in @ludwigschwardt  's other PR. (perhaps limiting that request to only work while 'Lock' is true).