### PR TITLE
Use bfcal tag for delay calibration (for now)

### DIFF
--- a/AR1/observations/calibrate_delays.py
+++ b/AR1/observations/calibrate_delays.py
@@ -96,7 +96,7 @@ with verify_and_connect(opts) as kat:
                                "please re-run the script later")
     # Pick source with the highest elevation as our target
     target = observation_sources.sort('el').targets[-1]
-    target.add_tags('delaycal single_accumulation')
+    target.add_tags('bfcal single_accumulation')
     # Start capture session
     with start_session(kat, **vars(opts)) as session:
         session.standard_setup(**vars(opts))


### PR DESCRIPTION
The seemingly more appropriate ```delaycal``` tag triggers a preliminary gain calibration followed by an actual delay calibration in the standard cal pipeline. This preliminary calibration can fail on some antennas, resulting in large residual delays.

Disable it implicitly by reverting to the ```bfcal``` tag. This is overkill, as the pipeline then also produces bandpass and gain solutions, but at least ensures that the first step is pure delay calibration (and since solutions are quickly available the timing is still the same).

A better solution would be to fix the ```delaycal``` tag or make yet another custom tag.

This closes JIRA ticket [MKAIV-594](https://skaafrica.atlassian.net/browse/MKAIV-594).