### PR TITLE
fixed renamed wind speed sensor from Enviro/wind_speed to Enviro/mean…

### DIFF
--- a/katsdpscripts/RTS/weatherlib.py
+++ b/katsdpscripts/RTS/weatherlib.py
@@ -16,7 +16,7 @@ def select_and_average(filename, average_time):
         raw_wind_speed = data.sensor.get('Enviro/asc.wind.speed')
         raw_temperature = data.sensor.get('Enviro/asc.air.temperature')
     else:
-        raw_wind_speed = data.sensor.get('Enviro/wind_speed')
+        raw_wind_speed = data.sensor.get('Enviro/mean_wind_speed')
         raw_temperature = data.sensor.get('Enviro/air_temperature')
     raw_dumptime = data.dump_period
 


### PR DESCRIPTION
This bug is causing condition_report reduction to fail on RTS:

Traceback (most recent call last):
  File "/var/kat/katsdpscripts/RTS/Condition_Report/condition_report.py", line 43, in <module>
    weather_report(args[0], output_dirname=opts.outputdir, average_time=opts.average)
  File "/usr/local/lib/python2.7/dist-packages/katsdpscripts/RTS/weatherlib.py", line 230, in weather_report
    timestamps, alltimestamps, wind_speed, temperature, dump_time, sun_distance, antenna = select_and_average(filename, average_time)
  File "/usr/local/lib/python2.7/dist-packages/katsdpscripts/RTS/weatherlib.py", line 19, in select_and_average
    raw_wind_speed = data.sensor.get('Enviro/wind_speed')
  File "/usr/local/lib/python2.7/dist-packages/katdal/sensordata.py", line 680, in get
    raise KeyError("Unknown sensor '%s' (does not match actual name or virtual template)" % (name,))
KeyError: "Unknown sensor 'Enviro/wind_speed' (does not match actual name or virtual template)"

