### PR TITLE
Reference pointing script

### DIFF
--- a/observation/reference_pointing.py
+++ b/observation/reference_pointing.py
@@ -331,10 +331,10 @@ def save_pointing_offsets(session, pointing_offsets, middle_time):
         Unix timestamp at the middle of sequence of offset pointings
 
     """
-    user_logger.info("Ant  refracted (az, el)    relative adjustment     "
+    user_logger.info("Ant  refracted (az, el)      relative adjustment     "
                      "standard dev")
-    user_logger.info("---  ------------------    -------------------     "
-                     "------------")
+    user_logger.info("---- --------------------    --------------------    "
+                     "--------------")
     for ant in session.observers:
         try:
             offsets = pointing_offsets[ant.name].copy()
@@ -346,7 +346,7 @@ def save_pointing_offsets(session, pointing_offsets, middle_time):
             session.telstate.add(sensor_name, offsets, middle_time)
             # Display all offsets in arcminutes
             offsets[2:] *= 60.
-            user_logger.info(u"%s (%+6.2f\u00B0, %5.2f\u00B0) -> "
+            user_logger.info("%s (%+6.2f, %5.2f) deg -> "
                              "(%+7.2f', %+7.2f') +- (%.2f', %.2f')",
                              ant.name, *offsets[[0, 1, 6, 7, 8, 9]])
 


### PR DESCRIPTION
This performs a basic interferometric pointing scan and then retrieves the appropriate gain solutions produced by the cal pipeline, fits primary beam models to them, calculates pointing offsets and finally saves the results back in telstate. There it will be picked up by future CaptureSessions running on the same subarray.
