### PR TITLE
Refine reference pointing script some more

### DIFF
--- a/observation/reference_pointing.py
+++ b/observation/reference_pointing.py
@@ -454,8 +454,8 @@ def save_pointing_offsets(session, pointing_offsets, middle_time):
         Unix timestamp at the middle of sequence of offset pointings
 
     """
-    user_logger.info("Ant  refracted (az, el)      relative adjustment")
-    user_logger.info("---- --------------------    --------------------")
+    user_logger.info("Ant  refracted (az, el)     relative adjustment")
+    user_logger.info("---- --------------------   --------------------")
     for ant in session.observers:
         try:
             offsets = pointing_offsets[ant.name].copy()


### PR DESCRIPTION
This mainly fixes a critical bug (a crash due to an unescaped % sign).

In addition, make the uncertainty calculations more accurate and then stop reporting the uncertainty because it is too good and therefore misleading...

Other small improvements are a more accurate middle time, not fitting beams on the edges of the band, and better debug output.