### PR TITLE
Tweak scripts for new cal pipeline

### DIFF
--- a/observation/basic_health.py
+++ b/observation/basic_health.py
@@ -120,7 +120,7 @@ with verify_and_connect(opts) as kat:
             session.ants.req.target('')
             user_logger.info("Waiting for gains to materialise in cal pipeline")
             # session.track('Nothing,special', duration=180, announce=False)
-            time.sleep(180)
+            time.sleep(60)
             delays = bp_gains = gains = {}
             cal_channel_freqs = None
             if not kat.dry_run:

--- a/observation/bf_phaseup.py
+++ b/observation/bf_phaseup.py
@@ -73,7 +73,7 @@ description = 'Track one or more sources for a specified time and calibrate ' \
               'gains based on them. At least one target must be specified.'
 parser = standard_script_options(usage, description)
 # Add experiment-specific options
-parser.add_option('-t', '--track-duration', type='float', default=60.0,
+parser.add_option('-t', '--track-duration', type='float', default=32.0,
                   help='Length of time to track each source, in seconds (default=%default)')
 parser.add_option('--reset', action='store_true', default=False,
                   help='Reset the gains to the default value afterwards')
@@ -138,7 +138,7 @@ with verify_and_connect(opts) as kat:
             # Attempt to jiggle cal pipeline to drop its gains
             session.ants.req.target('')
             user_logger.info("Waiting for gains to materialise in cal pipeline")
-            time.sleep(180)
+            time.sleep(60)
             delays = bp_gains = gains = {}
             cal_channel_freqs = None
             if not kat.dry_run:

--- a/observation/calibrate_delays.py
+++ b/observation/calibrate_delays.py
@@ -69,7 +69,7 @@ description = 'Track the source with the highest elevation and calibrate ' \
               'delays based on it. At least one target must be specified.'
 parser = standard_script_options(usage, description)
 # Add experiment-specific options
-parser.add_option('-t', '--track-duration', type='float', default=30.0,
+parser.add_option('-t', '--track-duration', type='float', default=32.0,
                   help='Length of time to track the source, in seconds (default=%default)')
 parser.add_option('--fengine-gain', type='int', default=0,
                   help='Correlator F-engine gain, automatically set if 0 (the '

--- a/observation/reference_pointing.py
+++ b/observation/reference_pointing.py
@@ -488,7 +488,7 @@ description = 'Perform offset pointings on the first source and obtain ' \
               'one target must be specified.'
 parser = standard_script_options(usage, description)
 # Add experiment-specific options
-parser.add_option('-t', '--track-duration', type='float', default=20.0,
+parser.add_option('-t', '--track-duration', type='float', default=16.0,
                   help='Duration of each offset pointing, in seconds (default=%default)')
 parser.add_option('--max-extent', type='float', default=1.0,
                   help='Maximum distance of offset from target, in degrees')
@@ -557,7 +557,7 @@ with verify_and_connect(opts) as kat:
         session.ants.req.offset_fixed(0., 0., opts.projection)
         user_logger.info("Waiting for gains to materialise in cal pipeline")
         # XXX Use the same sleep as bf_phaseup for now
-        time.sleep(180)
+        time.sleep(60)
 
         # Perform basic interferometric pointing reduction
         if not kat.dry_run:


### PR DESCRIPTION
This mainly fixes a bug in calibrate_delays.py that upset JSON (see [MKAIV-727](https://skaafrica.atlassian.net/browse/MKAIV-727)).

In addition, improve the scripts that interact with the pipeline by allowing shorter waits and track durations and standardising on the `bfcal` tag. The reference pointing script saw some cleanups and improved efficiencies.