### PR TITLE
Hotfix/lance/update endurance test

### DIFF
--- a/AR1/drive_antennas/AP_endurance.py
+++ b/AR1/drive_antennas/AP_endurance.py
@@ -250,7 +250,7 @@ parser.add_option('--num-repeat', type='int',
                   default=1,
                   help='The number of times to repeat the sequence (once by by default)')
 parser.add_option('--ap', type='str',                                   
-                  default="m036",                                                    
+                  default="m036",
                   help='Receptor under test (default is m036)')
 
 # Parse the command line
@@ -258,10 +258,6 @@ opts, args = parser.parse_args()
 
 if opts.observer is None:
     raise RuntimeError("No observer provided script")
-
-if len(args) == 0:
-    raise RuntimeError("No targets and indexer positions"
-                       "provided to the script")
 
 receptor = None
 


### PR DESCRIPTION
Some slight clean up of the endurance script ahead of the next round of testing. Example of sb instruction set for testing the newly adjusted hardware limits on site:

obs.sb.instruction_set = "run-obs-script /home/kat/katsdpscripts/AR1/drive_antennas/AP_endurance.py --start-az=-135 --start-el=14.6 --num-repeat=10 --proposal-id='RTS'  "