### PR TITLE
2.1 uhf tipping curve

### DIFF
--- a/RTS/2.1-Tipping_Curve/red_tipping_curve.py
+++ b/RTS/2.1-Tipping_Curve/red_tipping_curve.py
@@ -114,7 +114,6 @@ class Spill_Temp:
 
             T_H = fit.Delaunay2DScatterFit()
             T_H.fit((90.-elevation_list,freq_list),data_list)
-            #raise RuntimeError('Stop for some Reason')
             elevation_list = np.array(())
             freq_list = np.array(())
             data_list = np.array(())
@@ -183,7 +182,6 @@ class aperture_efficiency_models:
             a800[1:-1,:] = aperture_eff_v
             a800[-1,:] = [aperture_eff_v[-1,0]+100,aperture_eff_v[-1,1]]# Extend the model by 100 MHz
             aperture_eff_v = a800
-            raise RuntimeError('sdfsdf')
         except IOError:
             aperture_eff_h = np.array([[1.,75.],[2000.,75.]])
             aperture_eff_v = np.array([[1.,75.],[2000.,75.]])


### PR DESCRIPTION
This is the update of the tipping curve reduction code to enable it to reduce UHF data .
What I need in katconfig are 
The Spillover models  for UHF :   currently defaults are 0 kelvin 
The Aperture efficiency models  for UHF  : currently defaults are 75%  

I also would like to know the edges of the usable band for UHF so I can put the  line indicators in correct position.

