### PR TITLE
Fix horizon checks in track.py

### DIFF
--- a/observation/track.py
+++ b/observation/track.py
@@ -31,7 +31,7 @@ parser.add_option('--reset-gain', type='int', default=None,
                   help='Value for the reset of the correlator F-engine gain '
                        '(default=%default)')
 # Set default value for any option (both standard and experiment-specific options)
-parser.set_defaults(description='Target track')
+parser.set_defaults(description='Target track', nd_params='off')
 # Parse the command line
 opts, args = parser.parse_args()
 
@@ -84,7 +84,7 @@ with verify_and_connect(opts) as kat:
                     duration = min(duration, time_left)
                 session.label('track')
                 if session.track(target, duration=duration):
-                    targets_observed.append(target.name)
+                    targets_observed.append(target.description)
             if keep_going and len(targets_observed) == targets_before_loop:
                 user_logger.warning("No targets are currently visible - "
                                     "stopping script instead of hanging around")


### PR DESCRIPTION
There is a bug in the horizon checking of `track.py` where the script attempts to track a target that is busy setting, but then ignores the failed track and attempts this ad infinitum. In a real observation the target eventually sets and the script quits. A dry-run, however, gets stuck on the same timestamp and generates reams of logs.

The solution involves a general cleanup of the tracking logic. The automatic splitting of tracks into noise diode periods has been removed, as this obfuscates a lot of the logic. By selecting a track
duration commensurate with the noise diode period, most of the script functionality is preserved. The only issue is with multiple targets having multiple noise diode firings per track each.

This addresses JIRA ticket [CB-2222](https://skaafrica.atlassian.net/browse/CB-2222).