### PR TITLE
Increase timeout to wait for delay calculations

### DIFF
--- a/observation/calibrate_delays.py
+++ b/observation/calibrate_delays.py
@@ -112,7 +112,7 @@ with verify_and_connect(opts) as kat:
         session.ants.req.target('')
 
         user_logger.info("Waiting for delays to materialise in cal pipeline")
-        time.sleep(30)
+        time.sleep(90)
         sample_rate = 0.0
         delays = {}
         if not kat.dry_run:


### PR DESCRIPTION
Mattieu reports pipeline times of 40 seconds, so make it 90.