### PR TITLE
Adding more ap sensors and altering receiver check

### DIFF
--- a/utility/check_ant.py
+++ b/utility/check_ant.py
@@ -33,7 +33,7 @@ def check_receivers(ant):
         raise RuntimeError("receiver state is unavailable")
 
     rxl_temp = ant.sensors.rsc_rxl_rfe1_temperature.get_value()
-    if rxl_temp <= 29.9:
+    if rxl_temp <= 30.0:
         print("L-band rfe1 temperature is ok :) currently at {:.3f}". format(rxl_temp))
         if not ant.sensor.rsc_rxl_lna_h_power_enabled.get_value():
             user_logger.warning(" L-band receiver hpol LNA power is not enabled. switch on the hpol LNA power")


### PR DESCRIPTION
The script now checks the state of the receiver and helium compressor. Ben Jordaan informed ops that receivers are usable even when the startup-state is "soft-off". @rubyvanrooyen, @ludwigschwardt, please review PR.   