### PR TITLE
Fix dry run failure in delay cal script

### DIFF
--- a/observation/calibrate_delays.py
+++ b/observation/calibrate_delays.py
@@ -97,7 +97,7 @@ with verify_and_connect(opts) as kat:
         # XXX Remove any NaNs due to failed fits (move this into set_delays)
         delays = {inp: delay for inp, delay in delays.items()
                   if not np.isnan(delay)}
-        if not delays and not opts.dry_run:
+        if not delays and not kat.dry_run:
             raise CalSolutionsUnavailable("No valid delay fits found "
                                           "(is everything flagged?)")
         session.set_delays(delays)


### PR DESCRIPTION
When doing a dry run there cannot be any valid delays, so don't abort.  This is currently running as an uncommitted change on site.

@ludwigschwardt I know you're not a fan of dry run checks - you're welcome to propose a different solution.