### PR TITLE
Use catalogue from katexternaldata for gps scans

### DIFF
--- a/AR1/gps_tests/gps_raster_scan.py
+++ b/AR1/gps_tests/gps_raster_scan.py
@@ -9,6 +9,7 @@ import numpy as np
 import time
 
 from katcorelib import standard_script_options, verify_and_connect, collect_targets, start_session, user_logger
+import katconf
 import katpoint
 
 # Set up standard script options
@@ -23,7 +24,12 @@ opts, args = parser.parse_args()
 with verify_and_connect(opts) as kat:
     observation_sources = katpoint.Catalogue(antenna=kat.sources.antenna)
     try:
-        observation_sources.add_tle(file(args[0]))
+        # load file from head node via katconf server (e.g. gps-ops.txt)
+        file_path = 'katexternaldata/catalogues/%s' % (args[0])
+        user_logger.info('Adding TLE from file: %s', file_path)
+        lines = katconf.resource_string(file_path).split('\n')
+        lines = [line + '\r\n' for line in lines if len(line) > 0]
+        observation_sources.add_tle(lines)
     except (IOError, ValueError):#IOError or ValueError : # If the file failed to load assume it is a target string
         args_target_obj = collect_targets(kat,args)
         observation_sources.add(args_target_obj)

--- a/AR1/gps_tests/linearity_scan.py
+++ b/AR1/gps_tests/linearity_scan.py
@@ -6,6 +6,7 @@ from __future__ import with_statement
 import numpy as np
 import time
 from katcorelib import collect_targets, standard_script_options, verify_and_connect,  start_session, user_logger
+import katconf
 import katpoint
 
 # Set up standard script options
@@ -40,7 +41,12 @@ with verify_and_connect(opts) as kat:
     args_target_list =[]
     observation_sources = katpoint.Catalogue(antenna=kat.sources.antenna)
     try:
-        observation_sources.add_tle(file(args[0]))
+        # load file from head node via katconf server (e.g. gps-ops.txt)
+        file_path = 'katexternaldata/catalogues/%s' % (args[0])
+        user_logger.info('Adding TLE from file: %s', file_path)
+        lines = katconf.resource_string(file_path).split('\n')
+        lines = [line + '\r\n' for line in lines if len(line) > 0]
+        observation_sources.add_tle(lines)
     except (IOError, ValueError):#IOError or ValueError : # If the file failed to load assume it is a target string
         args_target_obj = collect_targets(kat,args)
         observation_sources.add(args_target_obj)


### PR DESCRIPTION
The `gps-opts.txt` catalogue file now lives in katexternaldata on the monctl node and is updated automatically.  Changed observation scripts to get the file contents via the katconf server instead, as the file is no longer available on the obs node.

Requested by @ssalieska for gps_raster_scan.

Example SB instruction set:
```
"run-obs-script /home/kat/katsdpscripts/AR1/gps_tests/gps_raster_scan.py gps-ops.txt --proposal-id='SE-AR1'"
```