### PR TITLE
Shout when a digitiser did not sync correctly

### DIFF
--- a/utility/global_sync.py
+++ b/utility/global_sync.py
@@ -148,7 +148,8 @@ with verify_and_connect(opts) as kat:
                         wait_time += dig_sleep
                         if wait_time >= 60:  # seconds
                             print ("ant %s could not sync with DMC, investigation "
-                                   "is required..." % ant.name)
+                                   "is required...!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+                                   % ant.name)
                             break
                 except Exception:
                     pass


### PR DESCRIPTION
Trivial change.  This just makes it a little more obvious that a digitiser did not synchronise with the DMC correctly during global sync.  Change already on site, just committing change permanently.