### PR TITLE
Add total duration to script

### DIFF
--- a/observation/image.py
+++ b/observation/image.py
@@ -96,5 +96,5 @@ with verify_and_connect(opts) as kat:
                                     'currently below horizon, stopping script')
                 loop = False
         for n, source in enumerate(sources):
-            user_logger.info('Source %s observed for %f hrs',
+            user_logger.info('Source %s observed for %.2f hrs',
                              source.description, source_total_duration[n] / 3600.0)


### PR DESCRIPTION
This will allow the observer to see the total time spent on each source at the end of an observation in the progress log. Also useful for dry run checking.