### PR TITLE
Fix analyse_interferometric_pointing.py to use MVFv4 file format

### DIFF
--- a/AR1/reduction/interferometric_pointing/analyse_interferometric_pointing.py
+++ b/AR1/reduction/interferometric_pointing/analyse_interferometric_pointing.py
@@ -78,7 +78,7 @@ def reduce_compscan_inf(h5 ,channel_mask = None,chunks=16,return_raw=False,use_w
                 if use_weights :
                     weights = h5.weights[valid_index].mean(axis=0)
                 else:
-                    weights = np.ones_like(data[:].mean(axis=0)).astype(np.float)
+                    weights = np.ones(data.shape[1:]).astype(np.float)
                 gains_p[pol].append(calprocs.g_fit(data[:].mean(axis=0),weights,h5.bls_lookup,refant=0) )
                 stdv[pol].append(np.ones((data.shape[0],data.shape[1],len(h5.ants))).sum(axis=0))#number of data points
                 # Get coords in (x(time,ants),y(time,ants) coords) 


### PR DESCRIPTION
These are the changes to the script so that it works with the new file format. There is a new option that available , it is the --use-weights option that would use the sdp weights. by default it has uniform weights .