### PR TITLE
Call capture_init in calibrate_delays.py

### DIFF
--- a/observation/calibrate_delays.py
+++ b/observation/calibrate_delays.py
@@ -77,7 +77,7 @@ with verify_and_connect(opts) as kat:
         user_logger.info("Zeroing all delay adjustments for starters")
         session.set_delays(delays)
         session.capture_init()
-        user_logger.warning("Only capture_start on correlator stream directly")
+        user_logger.info("Only calling capture_start on correlator stream directly")
         session.cbf.correlator.req.capture_start()
         user_logger.info("Initiating %g-second track on target %r",
                          opts.track_duration, target.description)


### PR DESCRIPTION
Calling `session.capture_start` secretly calls `session.capture_init`, so removing the former, as done in PR #319, broke things.  Now calling `session.capture_init` explicitly.