### PR TITLE
Update default requant gains in observation scripts

### DIFF
--- a/observation/bf_phaseup.py
+++ b/observation/bf_phaseup.py
@@ -69,10 +69,10 @@ with verify_and_connect(opts) as kat:
         gains = {}
         if not opts.default_gain:
             num_channels = session.cbf.fengine.sensor.n_chans.get_value()
-            try :
+            try:
                 opts.default_gain = DEFAULT_GAIN[num_channels]
             except KeyError:
-                raise KeyError("%i channel mode not present in dict of valid modes" % num_channels)
+                raise KeyError("No default gain available for F-engine with %i channels - please specify --fengine-gain" % num_channels)
         user_logger.info("Resetting F-engine gains to %g to allow phasing up",
                          opts.default_gain)
         for inp in session.cbf.fengine.inputs:

--- a/observation/calibrate_delays.py
+++ b/observation/calibrate_delays.py
@@ -66,10 +66,10 @@ with verify_and_connect(opts) as kat:
         session.standard_setup(**vars(opts))
         if opts.fengine_gain <= 0:
             num_channels = session.cbf.fengine.sensor.n_chans.get_value()
-            try :
+            try:
                 opts.fengine_gain = DEFAULT_GAIN[num_channels]
             except KeyError:
-                raise KeyError("%i channel mode not present in dict of valid modes" % num_channels)
+                raise KeyError("No default gain available for F-engine with %i channels - please specify --fengine-gain" % num_channels)
         gains = {}
         delays = {}
         for inp in session.get_cal_inputs():


### PR DESCRIPTION
This is an update to default requant gains dict with approriate requant gain values that have been determined from mesurements. The 1k has a value of 116 for a FFT shift of 255 the 4k has a gain value of 70 for a FFT shift of 511 anf the 32K has a gain of 360 for a FFT of 511.