### PR TITLE
Update scripts to set last phase up and last delay calibration info 

### DIFF
--- a/observation/bf_phaseup.py
+++ b/observation/bf_phaseup.py
@@ -141,5 +141,6 @@ with verify_and_connect(opts) as kat:
                 session.label('corrected')
                 session.track(target, duration=opts.verify_duration, announce=False)
 
-        # Set last-phaseup script sensor on the subarray.
-        session.sub.req.set_script_param('script-last-phaseup', kat.sb_id_code)
+            if not opts.random_phase:
+                # Set last-phaseup script sensor on the subarray.
+                session.sub.req.set_script_param('script-last-phaseup', kat.sb_id_code)

--- a/observation/calibrate_delays.py
+++ b/observation/calibrate_delays.py
@@ -118,6 +118,6 @@ with verify_and_connect(opts) as kat:
             for inp in delays:
                 delays[inp] = 0.0
             session.set_delays(delays)
-
-        # Set last-delay-calibration script sensor on the subarray.
-        session.sub.req.set_script_param('script-last-delay-calibration', kat.sb_id_code)
+        else:
+            # Set last-delay-calibration script sensor on the subarray.
+            session.sub.req.set_script_param('script-last-delay-calibration', kat.sb_id_code)


### PR DESCRIPTION
Change phaseup and delay cal scripts to update the 

`subarray_<n>.script-last-phaseup`
`subarray_<n>.script-last-delay-calibration`

sensors on the subarray. 

JIRA: [MT-319](https://skaafrica.atlassian.net/browse/MT-319)