### PR TITLE
Warn on low data rates in check_cbf_skarab.py

### DIFF
--- a/utility/check_cbf_skarab.py
+++ b/utility/check_cbf_skarab.py
@@ -38,7 +38,7 @@ parser = standard_script_options(
     description="MeerKAT SKARAB CBF error check")
 parser.add_option("--subnr", type=int, default=1,
                   help="Subarray to check. (default='%default')")
-parser.add_option("--strategy", default="once",
+parser.add_option("--strategy", default="detail",
                   help="Strategy for this script. 'once|period|detail' "
                        "(default='%default')")
 
@@ -287,11 +287,13 @@ with cambuild(sub_nr=subnr) as kat:
             sens = []
             for inform in informs:
                 timestamp, _count, name, status, value = inform.arguments
-                special = False
-                if name.endswith('x-gbps'):
-                    special = value < 1.0  # flag very low rx and tx rates as well
+                special = ""
+                if name.endswith('-gbps'):
+                    if float(value) < 1.0:
+                        special = "*** low data rate - host disabled?"
                 if status in sens_statuses or special:
-                    sens.append((name, float(timestamp), reading_time, status, value))
+                    sens.append(
+                        (name, float(timestamp), reading_time, status, value, special))
 
             print('Filter: {}, Status: {},  {}/{} sensors\n'
                   .format(sens_filter, sens_status, len(sens), reply.arguments[1]))
@@ -300,7 +302,7 @@ with cambuild(sub_nr=subnr) as kat:
             xhosts_warn = set()
             fhosts_warn = set()
             for s in sens:
-                (name, value_time, reading_time, status, value) = s
+                (name, value_time, reading_time, status, value, special) = s
                 if name.startswith("i0.fhost"):
                     errors = fhosts_error
                     warns = fhosts_warn
@@ -312,7 +314,7 @@ with cambuild(sub_nr=subnr) as kat:
                 host = name.split(".")[1]
                 if status in ['error', 'failure', 'unknown']:
                     errors.add(host)
-                elif status in ['warn']:
+                elif status in ['warn'] or special:
                     warns.add(host)
 
             if fhosts_error or fhosts_warn:
@@ -398,16 +400,17 @@ with cambuild(sub_nr=subnr) as kat:
                 numpages, rest = divmod(len(sens), perpage or 1)
                 numpages = numpages + (1 if rest > 0 else 0)
             for s in sens[page * perpage:page * perpage + perpage]:
-                (name, value_time, reading_time, status, value) = s
+                (name, value_time, reading_time, status, value, special) = s
                 colour = get_sensor_colour(status)
                 # truncate value to first 75 characters
                 value = value if len(value) <= 100 or not truncate else value[:95] + "..."
                 value = r"\n".join(value.splitlines())
-                print("%s %s %s %s %s" % (col(colour) + name.ljust(45),
+                print("%s %s %s %s %s %s" % (col(colour) + name.ljust(45),
                       status.ljust(10),
                       get_time_str(value_time).ljust(15),
                       get_time_str(reading_time).ljust(15),
-                      str(value).ljust(45) + col('normal')))
+                      str(value).ljust(45),
+                      special + col('normal')))
                 sys.stdout.flush()
 
     except KeyboardInterrupt:


### PR DESCRIPTION
- Fix check for low data rates from a host and make it more clear.
- Also change default strategy to provide detail, as this is the option most commonly used.