### PR TITLE
Add AP Rate Slew Test Script

### DIFF
--- a/AR1/drive_antennas/AP_rate_test.py
+++ b/AR1/drive_antennas/AP_rate_test.py
@@ -26,7 +26,7 @@ def rate_slew(ants, azim, elev, speed=0.5, reverse=False, dry_run=False):
     elev_speed = 0.0
     sensor_name = "ap.actual-azim"
     # Only testing 365 degrees, not full travel range (460 degrees)
-    expected_azim = [azim + 365.0 if speed > 0 else azim - 365.0]
+    expected_azim = (azim + 365.0 if speed > 0 else azim - 365.0)
     # Position threshold 2 degrees to catch it at 0.5 second polling
     # period at full speed (2 deg/sec).
     threshold = 2


### PR DESCRIPTION
This PR is to add an engineering test script which uses the MeerKat AP's 'rate' command to perform slews at user defined speeds. This version of the script only slews in azimuth. It includes a speed option (specified in degrees per second) and a 'reverse' option which will perform the same speed slew in the opposite direction.