### PR TITLE
Remove tags from pointing targets to avoid overloading the cal pipeline

### DIFF
--- a/observation/interferometric_pointing.py
+++ b/observation/interferometric_pointing.py
@@ -87,7 +87,7 @@ with verify_and_connect(opts) as kat:
                             session.ants.req.offset_fixed(offset_target[0], offset_target[1], opts.projection)
                         nd_params = session.nd_params
                         #session.fire_noise_diode(announce=True, **nd_params)
-                        target.tags = target.tags[:1]  # this is to not to overload the cal pipeline
+                        target.tags = target.tags[:1]  # this is to avoid overloading the cal pipeline
                         session.track(target, duration=opts.track_duration, announce=False)
                 targets_observed.append(target.name)
                 if opts.max_duration is not None and (time.time() - start_time >= opts.max_duration):


### PR DESCRIPTION
This is the requested change to the script. @ludwigschwardt has suggested the change to reduce load on the pipeline but I have conflicting feelings about this. The pipeline products are not used in this script reduction or process so it is safe to not generate these. But I feel that this will be hiding the problem with the pipeline being unable to keep up with the data. The reduction of the data with the standard reduction script which uses the same routines in the pipeline is faster, despite doing much more calculations, it does 16  sub-bands and then does gaussian fitting, while the pipeline does one subbed and no fitting . 

Description of the change below
The pipeline tags are removed from the targets that are used in the pointing to reduce the computational load on the pipeline. we discard all tags except the first which is the co-ordinate tag.