### PR TITLE
Rework calibrator selection in phase-up scripts

### DIFF
--- a/observation/basic_health.py
+++ b/observation/basic_health.py
@@ -55,24 +55,25 @@ with verify_and_connect(opts) as kat:
         if len(session.ants) < 4:
             raise ValueError('Not enough receptors to do calibration - you '
                              'need 4 and you have %d' % (len(session.ants),))
-        if len(observation_sources.filter(el_limit_deg=opts.horizon)) == 0:
+        sources_above_horizon = observation_sources.filter(el_limit_deg=opts.horizon)
+        if not sources_above_horizon:
             raise NoTargetsUpError("No targets are currently visible - "
                                    "please re-run the script later")
-        session.standard_setup(**vars(opts))
         # Get the centre frequency of the band in MHz for flux calculations
         # TODO: check if this is the most suitable way (especially for UHF)
-        observation_sources.flux_freq_MHz = session.get_centre_freq()
+        sources_above_horizon.flux_freq_MHz = session.get_centre_freq()
         # Pick source with the biggest flux density at centre freq as our target
         # or fall back to source with highest elevation if flux isn't available
-        sources_with_valid_flux = observation_sources.filter(flux_limit_Jy=0)
+        sources_with_valid_flux = sources_above_horizon.filter(flux_limit_Jy=0)
         if sources_with_valid_flux:
             target = sources_with_valid_flux.sort('flux').targets[-1]
         else:
             user_logger.warning("Could not determine flux density at %f MHz "
                                 "of any target - picking highest one instead",
-                                observation_sources.flux_freq_MHz)
-            target = observation_sources.sort('el').targets[-1]
+                                sources_above_horizon.flux_freq_MHz)
+            target = sources_above_horizon.sort('el').targets[-1]
         target.add_tags('bfcal single_accumulation')
+        session.standard_setup(**vars(opts))
         # Calibration tests
         user_logger.info("Performing calibration tests")
         if opts.fengine_gain <= 0:

--- a/observation/bf_phaseup.py
+++ b/observation/bf_phaseup.py
@@ -138,7 +138,6 @@ with verify_and_connect(opts) as kat:
         sdp.req.product_reconfigure()
     # Start capture session, which creates HDF5 file
     with start_session(kat, **vars(opts)) as session:
-        # Quit early if there are no sources to observe or not enough antennas
         session.standard_setup(**vars(opts))
         if opts.fft_shift is not None:
             session.cbf.fengine.req.fft_shift(opts.fft_shift)
@@ -155,26 +154,28 @@ with verify_and_connect(opts) as kat:
         gains = {inp: opts.fengine_gain for inp in session.cbf.fengine.inputs}
         session.set_fengine_gains(gains)
         if not opts.reset:
-            observation_sources = collect_targets(kat, args)
+            # Quit early if there are no sources to observe or not enough antennas
             if len(session.ants) < 4:
                 raise ValueError('Not enough receptors to do calibration - you '
                                  'need 4 and you have %d' % (len(session.ants),))
-            if len(observation_sources.filter(el_limit_deg=opts.horizon)) == 0:
+            observation_sources = collect_targets(kat, args)
+            sources_above_horizon = observation_sources.filter(el_limit_deg=opts.horizon)
+            if not sources_above_horizon:
                 raise NoTargetsUpError("No targets are currently visible - "
                                        "please re-run the script later")
             # Get the centre frequency of the band in MHz for flux calculations
             # TODO: check if this is the most suitable way (especially for UHF)
-            observation_sources.flux_freq_MHz = session.get_centre_freq()
+            sources_above_horizon.flux_freq_MHz = session.get_centre_freq()
             # Pick source with the biggest flux density at centre freq as our target
             # or fall back to source with highest elevation if flux isn't available
-            sources_with_valid_flux = observation_sources.filter(flux_limit_Jy=0)
+            sources_with_valid_flux = sources_above_horizon.filter(flux_limit_Jy=0)
             if sources_with_valid_flux:
                 target = sources_with_valid_flux.sort('flux').targets[-1]
             else:
                 user_logger.warning("Could not determine flux density at %f MHz "
                                     "of any target - picking highest one instead",
-                                    observation_sources.flux_freq_MHz)
-                target = observation_sources.sort('el').targets[-1]
+                                    sources_above_horizon.flux_freq_MHz)
+                target = sources_above_horizon.sort('el').targets[-1]
             target.add_tags('bfcal single_accumulation')
             user_logger.info("Target to be observed: %s", target.description)
             session.capture_init()


### PR DESCRIPTION
Remove the hard-coded calibrators from the `bf_phaseup` and `basic_health` scripts. Rather pass the standard calibrators to the scripts via a catalogue file like `three_calib.csv` on the command line. This is more flexible in case we want to update these models again in the future.

Pick the strongest calibrator (i.e. largest flux density at some frequency) instead of the highest one. This will ensure better gain solutions. The chosen frequency is nominally the delay tracking frequency at the centre of the band (1284 MHz for L-band), but this has to be double-checked.

If no targets have proper fluxes, fall back to the highest one. This allows quick checks on new sources without waiting for flux models.

Another PR will actually replace 3C286 with J0825-5010 in `katsdpcatalogues`.