### PR TITLE
Update global_sync script for UHF

### DIFF
--- a/utility/global_sync.py
+++ b/utility/global_sync.py
@@ -35,9 +35,6 @@ parser.add_option('--configdelayfile', type="string",
                   default='katconfig/user/delay-models/mkat/pps_delays.csv',
                   help='Specify the katconfig path to the csv file containing receptor '
                        'delays in the format m0xx, <delay> (default="%default")')
-parser.add_option('--mcpsetband', type="string", default='',
-                  help='If specified, script will call cam.mcp.req.set_band() '
-                       'with given parameter (default="%default")')
 parser.add_option('--all', action="store_true", default=False,
                   help='Include all antennas in the global sync')
 # assume basic options passed from instruction_set
@@ -46,12 +43,6 @@ parser.set_defaults(description='MeerKAT Global sync')
 print("global_sync_MeerKAT script: start")
 
 bands = ['l', 'u']
-if opts.mcpsetband and opts.mcpsetband not in bands:
-    raise RuntimeError(
-        'Unavailable band: mcpsetband has been specified as {}. (Available bands: {})'
-        .format(opts.mcpsetband, band)
-    )
-
 dmc_epoch = None
 with verify_and_connect(opts) as kat:
     print("_______________________")


### PR DESCRIPTION
This PR does the following:
- [x] Adds support for both L and U band global sync setup.
- [x] Mild reformatting.


# Demo

## Before
`M016` and `M061` failed to sync, then we manually `sync'd` them.
![Peek 2019-08-07 12-05](https://user-images.githubusercontent.com/7910856/62614505-d15fb500-b90b-11e9-82bb-d30d3661e324.gif)

## After
`M016` and `M061` sync'd successfully.
![Peek 2019-08-07 12-22](https://user-images.githubusercontent.com/7910856/62615800-4b913900-b90e-11e9-8242-aa28c7daccaa.gif)

`

JIRA: [MT-855](https://skaafrica.atlassian.net/browse/MT-855)