### PR TITLE
Upgrade F-engine interaction in calibrate_delays and bf_phaseup

### DIFF
--- a/observation/bf_phaseup.py
+++ b/observation/bf_phaseup.py
@@ -89,15 +89,10 @@ def calculate_corrections(G_gains, B_gains, delays, cal_channel_freqs,
     return gain_corrections
 
 
-# Default F-engine gain as a function of number of channels
-DEFAULT_GAIN = {1024: 116, 4096: 70, 32768: 360}
-
-
 # Set up standard script options
 usage = "%prog [options] <'target/catalogue'> [<'target/catalogue'> ...]"
-description = 'Track the source with the largest flux density which is above ' \
-              'the horizon and calibrate gains based on it. At least one ' \
-              'target must be specified.'
+description = 'Track the first source above the horizon and calibrate ' \
+              'gains based on it. At least one target must be specified.'
 parser = standard_script_options(usage, description)
 # Add experiment-specific options
 parser.add_option('-t', '--track-duration', type='float', default=64.0,
@@ -106,20 +101,19 @@ parser.add_option('-t', '--track-duration', type='float', default=64.0,
 parser.add_option('--verify-duration', type='float', default=64.0,
                   help='Length of time to revisit the source for verification, '
                        'in seconds (default=%default)')
-parser.add_option('--fengine-gain', type='int', default=0,
-                  help='Override correlator F-engine gain (average magnitude), '
-                       'using the default gain value for the mode if 0')
+parser.add_option('--fengine-gain', type='int_or_default', default='default',
+                  help='Set correlator F-engine gain (average magnitude)')
+parser.add_option('--fft-shift', type='int_or_default',
+                  help='Override correlator F-engine FFT shift')
 parser.add_option('--flatten-bandpass', action='store_true', default=False,
-                  help='Applies magnitude bandpass correction in addition to phase correction')
+                  help='Apply bandpass magnitude correction on top of phase correction')
 parser.add_option('--random-phase', action='store_true', default=False,
-                  help='Applies random phases in F-engines')
-parser.add_option('--fft-shift', type='int',
-                  help='Set correlator F-engine FFT shift (default=leave as is)')
+                  help='Apply random phases in F-engine (incoherent beamformer)')
 parser.add_option('--reconfigure-sdp', action="store_true", default=False,
                   help='Reconfigure SDP subsystem at the start to clear crashed containers')
 # Set default value for any option (both standard and experiment-specific options)
 parser.set_defaults(observer='comm_test', nd_params='off', project_id='COMMTEST',
-                    description='Phase-up observation that sets the F-engine weights')
+                    description='Phase-up observation that sets F-engine gains')
 # Parse the command line
 opts, args = parser.parse_args()
 
@@ -134,23 +128,8 @@ with verify_and_connect(opts) as kat:
         user_logger.info("Reconfiguring SDP subsystem")
         sdp = SessionSDP(kat)
         sdp.req.product_reconfigure()
-    # Start capture session, which creates HDF5 file
+    # Start capture session
     with start_session(kat, **vars(opts)) as session:
-        session.standard_setup(**vars(opts))
-        if opts.fft_shift is not None:
-            session.cbf.fengine.req.fft_shift(opts.fft_shift)
-        if opts.fengine_gain <= 0:
-            num_channels = session.cbf.fengine.sensor.n_chans.get_value()
-            try:
-                opts.fengine_gain = DEFAULT_GAIN[num_channels]
-            except KeyError:
-                raise KeyError("No default gain available for F-engine with "
-                               "%i channels - please specify --fengine-gain"
-                               % (num_channels,))
-        user_logger.info("Resetting F-engine gains to %g to allow phasing up",
-                         opts.fengine_gain)
-        gains = {inp: opts.fengine_gain for inp in session.cbf.fengine.inputs}
-        session.set_fengine_gains(gains)
         # Quit early if there are no sources to observe or not enough antennas
         if len(session.ants) < 4:
             raise ValueError('Not enough receptors to do calibration - you '
@@ -165,6 +144,10 @@ with verify_and_connect(opts) as kat:
         target = sources_above_horizon.targets[0]
         target.add_tags('bfcal single_accumulation')
         user_logger.info("Target to be observed: %s", target.description)
+        session.standard_setup(**vars(opts))
+        if opts.fft_shift is not None:
+            session.set_fengine_fft_shift(opts.fft_shift)
+        fengine_gain = session.set_fengine_gains(opts.fengine_gain)
         session.capture_init()
         session.cbf.correlator.req.capture_start()
         session.label('un_corrected')
@@ -182,13 +165,14 @@ with verify_and_connect(opts) as kat:
         bp_gains = clean_bandpass(bp_gains, cal_channel_freqs, max_gap_Hz=64e6)
 
         if opts.random_phase:
-            user_logger.info("Setting F-engine gains with random phases")
+            user_logger.warning("Setting F-engine gains with random phases "
+                                "(you asked for it)")
         else:
             user_logger.info("Setting F-engine gains to phase up antennas")
         if not kat.dry_run:
             corrections = calculate_corrections(gains, bp_gains, delays,
                                                 cal_channel_freqs, opts.random_phase,
-                                                opts.flatten_bandpass, opts.fengine_gain)
+                                                opts.flatten_bandpass, fengine_gain)
             session.set_fengine_gains(corrections)
         if opts.verify_duration > 0:
             user_logger.info("Revisiting target %r for %g seconds to verify phase-up",

--- a/observation/calibrate_delays.py
+++ b/observation/calibrate_delays.py
@@ -7,42 +7,35 @@
 # 5 April 2017
 #
 
-import numpy as np
 from katcorelib.observe import (standard_script_options, verify_and_connect,
-                                collect_targets, start_session, user_logger,
-                                CalSolutionsUnavailable)
+                                collect_targets, start_session, user_logger)
 
 
 class NoTargetsUpError(Exception):
     """No targets are above the horizon at the start of the observation."""
 
 
-# Default F-engine gain as a function of number of channels
-DEFAULT_GAIN = {1024: 1856, 4096: 1120, 32768: 5760}
-
 # Set up standard script options
 usage = "%prog [options] <'target/catalogue'> [<'target/catalogue'> ...]"
-description = 'Track the source with the largest flux density which is above ' \
-              'the horizon and calibrate delays based on it. At least one ' \
-              'target must be specified.'
+description = 'Track the first source above the horizon and calibrate ' \
+              'delays based on it. At least one target must be specified.'
 parser = standard_script_options(usage, description)
 # Add experiment-specific options
 parser.add_option('-t', '--track-duration', type='float', default=32.0,
                   help='Length of time to track the source for calibration, '
                        'in seconds (default=%default)')
 parser.add_option('--verify-duration', type='float', default=64.0,
-                  help='Length of time to revisit source for verification, '
+                  help='Length of time to revisit the source for verification, '
                        'in seconds (default=%default)')
-parser.add_option('--fengine-gain', type='int', default=0,
-                  help='Override correlator F-engine gain, using the default '
-                       'gain value for the mode if 0')
-parser.add_option('--fft-shift', type='int',
-                  help='Set correlator F-engine FFT shift (default=leave as is)')
+parser.add_option('--fengine-gain', type='int_or_default', default='default',
+                  help='Set correlator F-engine gain')
+parser.add_option('--fft-shift', type='int_or_default', default='default',
+                  help='Set correlator F-engine FFT shift')
 parser.add_option('--reset-delays', action='store_true', default=False,
-                  help='Zero the delay adjustments afterwards')
+                  help='Zero the delay adjustments afterwards (i.e. check only)')
 # Set default value for any option (both standard and experiment-specific options)
 parser.set_defaults(observer='comm_test', nd_params='off', project_id='COMMTEST',
-                    description='Delay calibration observation')
+                    description='Delay calibration observation that adjusts delays')
 # Parse the command line
 opts, args = parser.parse_args()
 
@@ -69,29 +62,17 @@ with verify_and_connect(opts) as kat:
         target = sources_above_horizon.targets[0]
         target.add_tags('bfcal single_accumulation')
         session.standard_setup(**vars(opts))
-        if opts.fft_shift is not None:
-            session.cbf.fengine.req.fft_shift(opts.fft_shift)
-        if opts.fengine_gain <= 0:
-            num_channels = session.cbf.fengine.sensor.n_chans.get_value()
-            try:
-                opts.fengine_gain = DEFAULT_GAIN[num_channels]
-            except KeyError:
-                raise KeyError("No default gain available for F-engine with "
-                               "%i channels - please specify --fengine-gain"
-                               % (num_channels,))
-        cal_inputs = session.get_cal_inputs()
-        gains = {inp: opts.fengine_gain for inp in cal_inputs}
-        delays = {inp: 0.0 for inp in cal_inputs}
-        session.set_fengine_gains(gains)
-        user_logger.info("Zeroing all delay adjustments for starters")
-        session.set_delays(delays)
+        session.set_fengine_fft_shift(opts.fft_shift)
+        session.set_fengine_gains(opts.fengine_gain)
+        session.adjust_fengine_delays(0)
         session.capture_init()
         user_logger.info("Only calling capture_start on correlator stream directly")
         session.cbf.correlator.req.capture_start()
         user_logger.info("Initiating %g-second track on target %r",
                          opts.track_duration, target.description)
         session.label('un_corrected')
-        session.track(target, duration=0)  # get onto the source
+        # Get onto the source
+        session.track(target, duration=0)
         # Fire noise diode during track
         session.fire_noise_diode(on=opts.track_duration, off=0)
         # Attempt to jiggle cal pipeline to drop its delay solutions
@@ -99,31 +80,20 @@ with verify_and_connect(opts) as kat:
         user_logger.info("Waiting for delays to materialise in cal pipeline")
         hv_delays = session.get_cal_solutions('KCROSS_DIODE', timeout=300.)
         delays = session.get_cal_solutions('K')
-        # Add hv_delay to total delay
-        for inp in sorted(delays):
+        # Add HV delay to total delay
+        for inp in delays:
             delays[inp] += hv_delays[inp]
-            if np.isnan(delays[inp]):
-                user_logger.warning("Delay fit failed on input %s (all its "
-                                    "data probably flagged)", inp)
-        # XXX Remove any NaNs due to failed fits (move this into set_delays)
-        delays = {inp: delay for inp, delay in delays.items()
-                  if not np.isnan(delay)}
-        if not delays and not kat.dry_run:
-            raise CalSolutionsUnavailable("No valid delay fits found "
-                                          "(is everything flagged?)")
-        session.set_delays(delays)
+        # The main course
+        session.adjust_fengine_delays(delays)
         if opts.verify_duration > 0:
             user_logger.info("Revisiting target %r for %g seconds "
                              "to see if delays are fixed",
                              target.name, opts.verify_duration)
             session.label('corrected')
-            session.track(target, duration=0)  # get onto the source
-            # Fire noise diode during track
+            session.track(target, duration=0)
             session.fire_noise_diode(on=opts.verify_duration, off=0)
         if opts.reset_delays:
-            user_logger.info("Zeroing all delay adjustments on CBF proxy")
-            delays = {inp: 0.0 for inp in delays}
-            session.set_delays(delays)
+            session.adjust_fengine_delays(0)
         else:
             # Set last-delay-calibration script sensor on the subarray.
             session.sub.req.set_script_param('script-last-delay-calibration',

--- a/observation/calibrate_delays.py
+++ b/observation/calibrate_delays.py
@@ -49,7 +49,12 @@ with verify_and_connect(opts) as kat:
     observation_sources = collect_targets(kat, args)
     # Start capture session
     with start_session(kat, **vars(opts)) as session:
-        # Quit early if there are no sources to observe or not enough antennas
+        session.standard_setup(**vars(opts))
+        # Reset F-engine to a known good state first
+        session.set_fengine_fft_shift(opts.fft_shift)
+        session.set_fengine_gains(opts.fengine_gain)
+        session.adjust_fengine_delays(0)
+        # Quit if there are no sources to observe or not enough antennas for cal
         if len(session.ants) < 4:
             raise ValueError('Not enough receptors to do calibration - you '
                              'need 4 and you have %d' % (len(session.ants),))
@@ -61,10 +66,6 @@ with verify_and_connect(opts) as kat:
         # the catalogue are ordered from highest to lowest priority)
         target = sources_above_horizon.targets[0]
         target.add_tags('bfcal single_accumulation')
-        session.standard_setup(**vars(opts))
-        session.set_fengine_fft_shift(opts.fft_shift)
-        session.set_fengine_gains(opts.fengine_gain)
-        session.adjust_fengine_delays(0)
         session.capture_init()
         user_logger.info("Only calling capture_start on correlator stream directly")
         session.cbf.correlator.req.capture_start()


### PR DESCRIPTION
Now that ska-sa/katcorelib#325 has landed, update the scripts to use the new machinery.

This gets rid of hard-coded default F-engine gains in the scripts and rely on the CBF 'default' setting instead (while still allowing manual overrides via the script options). The same goes for the FFT shift.

The new `session.adjust_fengine_delays` method also cleans up the calibrate_delays script by taking care of any NaNs and also providing a simpler way to zero the delays.

Remove the `--reset` option from `bf_phaseup` as it only adds indentation for no benefit. And improve docs + comments.