### PR TITLE
Apply BCROSS_DIODE_SKY aka HV phase corrections

### DIFF
--- a/observation/bf_phaseup.py
+++ b/observation/bf_phaseup.py
@@ -148,20 +148,34 @@ with verify_and_connect(opts) as kat:
         # the catalogue are ordered from highest to lowest priority)
         target = sources_above_horizon.targets[0]
         target.add_tags('bfcal single_accumulation')
-        user_logger.info("Target to be observed: %s", target.description)
         session.capture_init()
         session.cbf.correlator.req.capture_start()
         session.label('un_corrected')
-        user_logger.info("Initiating %g-second track on target '%s'",
-                         opts.track_duration, target.name)
-        session.track(target, duration=opts.track_duration, announce=False)
+        # Get onto the source
+        user_logger.info("Initiating %g-second track on target %r",
+                         opts.track_duration, target.description)
+        session.track(target, duration=0, announce=False)
+        # Fire noise diode during track
+        session.fire_noise_diode(on=opts.track_duration, off=0)
         # Attempt to jiggle cal pipeline to drop its gains
         session.stop_antennas()
         user_logger.info("Waiting for gains to materialise in cal pipeline")
         # Wait for the last bfcal product from the pipeline
-        gains = session.get_cal_solutions('G', timeout=opts.track_duration)
+        hv_gains = session.get_cal_solutions('BCROSS_DIODE',
+                                             timeout=opts.track_duration)
+        hv_delays = session.get_cal_solutions('KCROSS_DIODE')
+        gains = session.get_cal_solutions('G')
         bp_gains = session.get_cal_solutions('B')
         delays = session.get_cal_solutions('K')
+        # Add HV delay to the usual delay
+        for inp in sorted(delays):
+            delays[inp] += hv_delays[inp]
+            if np.isnan(delays[inp]):
+                user_logger.warning("Delay fit failed on input %s (all its "
+                                    "data probably flagged)", inp)
+        # Add HV phase to bandpass phase
+        for inp in bp_gains:
+            bp_gains[inp] *= hv_gains[inp]
         cal_channel_freqs = session.get_cal_channel_freqs()
         bp_gains = clean_bandpass(bp_gains, cal_channel_freqs, max_gap_Hz=64e6)
 
@@ -176,10 +190,11 @@ with verify_and_connect(opts) as kat:
                                                 opts.flatten_bandpass, fengine_gain)
             session.set_fengine_gains(corrections)
         if opts.verify_duration > 0:
-            user_logger.info("Revisiting target %r for %g seconds to verify phase-up",
-                             target.name, opts.verify_duration)
             session.label('corrected')
-            session.track(target, duration=opts.verify_duration, announce=False)
+            user_logger.info("Revisiting target %r for %g seconds to verify "
+                             "phase-up", target.name, opts.verify_duration)
+            session.track(target, duration=0, announce=False)
+            session.fire_noise_diode(on=opts.verify_duration, off=0)
 
         if not opts.random_phase:
             # Set last-phaseup script sensor on the subarray.

--- a/observation/bf_phaseup.py
+++ b/observation/bf_phaseup.py
@@ -149,18 +149,20 @@ with verify_and_connect(opts) as kat:
         target = sources_above_horizon.targets[0]
         target.add_tags('bfcal single_accumulation')
         session.capture_init()
+        user_logger.info("Only calling capture_start on correlator stream")
         session.cbf.correlator.req.capture_start()
+        user_logger.info("--------------------------")
         session.label('un_corrected')
-        # Get onto the source
         user_logger.info("Initiating %g-second track on target %r",
                          opts.track_duration, target.description)
+        # Get onto the source
         session.track(target, duration=0, announce=False)
         # Fire noise diode during track
         session.fire_noise_diode(on=opts.track_duration, off=0)
-        # Attempt to jiggle cal pipeline to drop its gains
+        # Attempt to jiggle cal pipeline to drop its gain solutions
         session.stop_antennas()
         user_logger.info("Waiting for gains to materialise in cal pipeline")
-        # Wait for the last bfcal product from the pipeline
+        # Wait for the last relevant bfcal product from the pipeline
         hv_gains = session.get_cal_solutions('BCROSS_DIODE',
                                              timeout=60 + opts.track_duration)
         hv_delays = session.get_cal_solutions('KCROSS_DIODE')

--- a/observation/bf_phaseup.py
+++ b/observation/bf_phaseup.py
@@ -162,7 +162,7 @@ with verify_and_connect(opts) as kat:
         user_logger.info("Waiting for gains to materialise in cal pipeline")
         # Wait for the last bfcal product from the pipeline
         hv_gains = session.get_cal_solutions('BCROSS_DIODE',
-                                             timeout=opts.track_duration)
+                                             timeout=60 + opts.track_duration)
         hv_delays = session.get_cal_solutions('KCROSS_DIODE')
         gains = session.get_cal_solutions('G')
         bp_gains = session.get_cal_solutions('B')

--- a/observation/calibrate_delays.py
+++ b/observation/calibrate_delays.py
@@ -67,18 +67,20 @@ with verify_and_connect(opts) as kat:
         target = sources_above_horizon.targets[0]
         target.add_tags('bfcal single_accumulation')
         session.capture_init()
-        user_logger.info("Only calling capture_start on correlator stream directly")
+        user_logger.info("Only calling capture_start on correlator stream")
         session.cbf.correlator.req.capture_start()
+        user_logger.info("--------------------------")
+        session.label('un_corrected')
         user_logger.info("Initiating %g-second track on target %r",
                          opts.track_duration, target.description)
-        session.label('un_corrected')
         # Get onto the source
-        session.track(target, duration=0)
+        session.track(target, duration=0, announce=False)
         # Fire noise diode during track
         session.fire_noise_diode(on=opts.track_duration, off=0)
         # Attempt to jiggle cal pipeline to drop its delay solutions
         session.stop_antennas()
         user_logger.info("Waiting for delays to materialise in cal pipeline")
+        # Wait for the last relevant bfcal product from the pipeline
         hv_delays = session.get_cal_solutions('KCROSS_DIODE', timeout=300.)
         delays = session.get_cal_solutions('K')
         # Add HV delay to total delay
@@ -87,11 +89,11 @@ with verify_and_connect(opts) as kat:
         # The main course
         session.adjust_fengine_delays(delays)
         if opts.verify_duration > 0:
+            session.label('corrected')
             user_logger.info("Revisiting target %r for %g seconds "
                              "to see if delays are fixed",
                              target.name, opts.verify_duration)
-            session.label('corrected')
-            session.track(target, duration=0)
+            session.track(target, duration=0, announce=False)
             session.fire_noise_diode(on=opts.verify_duration, off=0)
         if opts.reset_delays:
             session.adjust_fengine_delays(0)


### PR DESCRIPTION
This is also known as "Phase Two of Polarisation Calibration". It does both Phase 2A (`BCROSS_DIODE`: HV phase derived from noise diode) and 2B (`BCROSS_DIODE_SKY`: noise diode HV phase transformed to sky).

Fire the noise diodes as part of phase-up (both initially and during verification). This triggers the cal pipeline to produce `KCROSS_DIODE` and `BCROSS_DIODE_SKY` solutions. Get those solutions from telstate and combine them with the K and B solutions, respectively.

Also do a few tweaks to the script logger output to synchronise this script with `calibrate_delays`, and remove somewhat spurious logs.

This addresses JIRA tickets [SR-1940](https://skaafrica.atlassian.net/browse/SR-1940) and [SR-1980](https://skaafrica.atlassian.net/browse/SR-1980).