### PR TITLE
Support multiple instruments aka narrowband

### DIFF
--- a/observation/basic_health.py
+++ b/observation/basic_health.py
@@ -61,10 +61,7 @@ with verify_and_connect(opts) as kat:
         # the catalogue are ordered from highest to lowest priority)
         target = sources_above_horizon.targets[0]
         target.add_tags('bfcal single_accumulation')
-        session.capture_init()
-        user_logger.info("Only calling capture_start on correlator streams")
-        for correlator in session.cbf.correlators:
-            correlator.req.capture_start()
+        session.capture_start()
         # Calibration tests
         user_logger.info("Performing calibration tests")
         session.label('calibration')

--- a/observation/basic_health.py
+++ b/observation/basic_health.py
@@ -79,7 +79,8 @@ with verify_and_connect(opts) as kat:
         gains = {inp: opts.fengine_gain for inp in session.cbf.fengine.inputs}
         session.set_fengine_gains(gains)
         session.capture_init()
-        session.cbf.correlator.req.capture_start()
+        for correlator in session.cbf.correlators:
+            correlator.req.capture_start()
         session.label('calibration')
         user_logger.info("Initiating %g-second track on target '%s'",
                          opts.track_duration, target.name)

--- a/observation/basic_health.py
+++ b/observation/basic_health.py
@@ -12,10 +12,6 @@ class NoTargetsUpError(Exception):
     """No targets are above the horizon at the start of the observation."""
 
 
-# Default F-engine gain as a function of number of channels
-DEFAULT_GAIN = {1024: 116, 4096: 70, 32768: 360}
-
-
 # Set up standard script options
 usage = "%prog [options] <'target/catalogue'> [<'target/catalogue'> ...]"
 description = 'Observe a bandpass calibrator to establish some ' \
@@ -25,9 +21,8 @@ parser = standard_script_options(usage, description)
 parser.add_option('--verify-duration', type='float', default=64.0,
                   help='Length of time to revisit source for verification, '
                        'in seconds (default=%default)')
-parser.add_option('--fengine-gain', type='int', default=0,
-                  help='Override correlator F-engine gain (average magnitude), '
-                       'using the default gain value for the mode if 0')
+parser.add_option('--fengine-gain', type='int_or_default', default='default',
+                  help='Set correlator F-engine gain (average magnitude)')
 # Set default value for any option (both standard and experiment-specific options)
 parser.set_defaults(observer='basic_health', nd_params='off',
                     project_id='MKAIV-308', reduction_label='MKAIV-308',
@@ -49,9 +44,12 @@ nd_on = {'diode': 'coupler', 'on': opts.track_duration, 'off': 0., 'period': 0.}
 with verify_and_connect(opts) as kat:
     observation_sources = collect_targets(kat, args)
     user_logger.info(observation_sources.visibility_list())
-    # Start capture session, which creates HDF5 file
+    # Start capture session
     with start_session(kat, **vars(opts)) as session:
-        # Quit early if there are no sources to observe or not enough antennas
+        session.standard_setup(**vars(opts))
+        # Reset F-engine to a known good state first
+        fengine_gain = session.set_fengine_gains(opts.fengine_gain)
+        # Quit if there are no sources to observe or not enough antennas for cal
         if len(session.ants) < 4:
             raise ValueError('Not enough receptors to do calibration - you '
                              'need 4 and you have %d' % (len(session.ants),))
@@ -63,24 +61,12 @@ with verify_and_connect(opts) as kat:
         # the catalogue are ordered from highest to lowest priority)
         target = sources_above_horizon.targets[0]
         target.add_tags('bfcal single_accumulation')
-        session.standard_setup(**vars(opts))
-        # Calibration tests
-        user_logger.info("Performing calibration tests")
-        if opts.fengine_gain <= 0:
-            num_channels = session.cbf.fengine.sensor.n_chans.get_value()
-            try:
-                opts.fengine_gain = DEFAULT_GAIN[num_channels]
-            except KeyError:
-                raise KeyError("No default gain available for F-engine with "
-                               "%i channels - please specify --fengine-gain"
-                               % (num_channels,))
-        user_logger.info("Resetting F-engine gains to %g to allow phasing up",
-                         opts.fengine_gain)
-        gains = {inp: opts.fengine_gain for inp in session.cbf.fengine.inputs}
-        session.set_fengine_gains(gains)
         session.capture_init()
+        user_logger.info("Only calling capture_start on correlator streams")
         for correlator in session.cbf.correlators:
             correlator.req.capture_start()
+        # Calibration tests
+        user_logger.info("Performing calibration tests")
         session.label('calibration')
         user_logger.info("Initiating %g-second track on target '%s'",
                          opts.track_duration, target.name)
@@ -107,7 +93,7 @@ with verify_and_connect(opts) as kat:
                 orig_weights *= delay_weights  # unwrap the delays
                 amp_weights = np.abs(orig_weights)
                 phase_weights = orig_weights / amp_weights
-                new_weights[inp] = opts.fengine_gain * phase_weights.conj()
+                new_weights[inp] = fengine_gain * phase_weights.conj()
         session.set_fengine_gains(new_weights)
         if opts.verify_duration > 0:
             user_logger.info("Revisiting target %r for %g seconds to verify phase-up",
@@ -157,6 +143,4 @@ with verify_and_connect(opts) as kat:
                             scan_extent=6.0, scan_spacing=0.25,
                             scan_in_azimuth=True, projection=opts.projection)
         # reset the gains always
-        user_logger.info("Resetting F-engine gains to %g", opts.fengine_gain)
-        gains = {inp: opts.fengine_gain for inp in gains}
-        session.set_fengine_gains(gains)
+        session.set_fengine_gains(opts.fengine_gain)

--- a/observation/bf_phaseup.py
+++ b/observation/bf_phaseup.py
@@ -149,10 +149,7 @@ with verify_and_connect(opts) as kat:
         target = sources_above_horizon.targets[0]
         target.add_tags('bfcal single_accumulation')
         user_logger.info("Target to be observed: %s", target.description)
-        session.capture_init()
-        user_logger.info("Only calling capture_start on correlator streams")
-        for correlator in session.cbf.correlators:
-            correlator.req.capture_start()
+        session.capture_start()
         session.label('un_corrected')
         user_logger.info("Initiating %g-second track on target '%s'",
                          opts.track_duration, target.name)

--- a/observation/bf_phaseup.py
+++ b/observation/bf_phaseup.py
@@ -150,6 +150,7 @@ with verify_and_connect(opts) as kat:
         target.add_tags('bfcal single_accumulation')
         user_logger.info("Target to be observed: %s", target.description)
         session.capture_init()
+        user_logger.info("Only calling capture_start on correlator streams")
         for correlator in session.cbf.correlators:
             correlator.req.capture_start()
         session.label('un_corrected')

--- a/observation/bf_phaseup.py
+++ b/observation/bf_phaseup.py
@@ -150,7 +150,8 @@ with verify_and_connect(opts) as kat:
         target.add_tags('bfcal single_accumulation')
         user_logger.info("Target to be observed: %s", target.description)
         session.capture_init()
-        session.cbf.correlator.req.capture_start()
+        for correlator in session.cbf.correlators:
+            correlator.req.capture_start()
         session.label('un_corrected')
         user_logger.info("Initiating %g-second track on target '%s'",
                          opts.track_duration, target.name)

--- a/observation/calibrate_delays.py
+++ b/observation/calibrate_delays.py
@@ -68,7 +68,8 @@ with verify_and_connect(opts) as kat:
         target.add_tags('bfcal single_accumulation')
         session.capture_init()
         user_logger.info("Only calling capture_start on correlator stream directly")
-        session.cbf.correlator.req.capture_start()
+        for correlator in session.cbf.correlators:
+            correlator.req.capture_start()
         user_logger.info("Initiating %g-second track on target %r",
                          opts.track_duration, target.description)
         session.label('un_corrected')

--- a/observation/calibrate_delays.py
+++ b/observation/calibrate_delays.py
@@ -67,7 +67,7 @@ with verify_and_connect(opts) as kat:
         target = sources_above_horizon.targets[0]
         target.add_tags('bfcal single_accumulation')
         session.capture_init()
-        user_logger.info("Only calling capture_start on correlator stream directly")
+        user_logger.info("Only calling capture_start on correlator streams")
         for correlator in session.cbf.correlators:
             correlator.req.capture_start()
         user_logger.info("Initiating %g-second track on target %r",

--- a/observation/calibrate_delays.py
+++ b/observation/calibrate_delays.py
@@ -66,10 +66,7 @@ with verify_and_connect(opts) as kat:
         # the catalogue are ordered from highest to lowest priority)
         target = sources_above_horizon.targets[0]
         target.add_tags('bfcal single_accumulation')
-        session.capture_init()
-        user_logger.info("Only calling capture_start on correlator streams")
-        for correlator in session.cbf.correlators:
-            correlator.req.capture_start()
+        session.capture_start()
         user_logger.info("Initiating %g-second track on target %r",
                          opts.track_duration, target.description)
         session.label('un_corrected')

--- a/observation/horizon_mask_scan.py
+++ b/observation/horizon_mask_scan.py
@@ -5,14 +5,15 @@ import time
 from katcorelib import standard_script_options, verify_and_connect, start_session, user_logger
 
 # Set up standard script options
-parser = standard_script_options(usage="%prog [options]",
-                                 description="Derive the horizon mask for a MeerKAT dish. Scan over constant elevation "
-                                             "range but loop over azimuth. This takes the form of 2x179 raster scans "
-                                             "in opposite directions, with 180*2 seconds per scan. "
-                                             "There are non-optional options.")
+description = ("Derive the horizon mask for a MeerKAT dish. Scan over constant elevation "
+               "range but loop over azimuth. This takes the form of 2x179 raster scans "
+               "in opposite directions, with 180*2 seconds per scan. "
+               "There are non-optional options.")
+parser = standard_script_options(usage="%prog [options]", description=description)
 # Add experiment-specific options
 parser.add_option('--elevation-range', dest='elevation_range', type="float", default=1.0,
-                  help="The range in elevation to cover starting from 3.1 degrees elevation (default=%default)")
+                  help="The range in elevation to cover starting from 3.1 degrees "
+                       "elevation (default=%default)")
 parser.add_option('--scan-spacing', dest='scan_spacing', type="float", default=1.0,
                   help="The spacing of the scan lines in the experiment, in degrees (default=%default)")
 parser.add_option('--reset-gain', type='int', default=None,
@@ -21,12 +22,12 @@ parser.add_option('--reset-gain', type='int', default=None,
 parser.add_option('--fft-shift', type='int',
                   help='Set correlator F-engine FFT shift (default=leave as is)')
 
-## Set default value for any option (both standard and experiment-specific options)
+# Set default value for any option (both standard and experiment-specific options)
 parser.set_defaults(description='Horizon mask')
 # Parse the command line
 opts, args = parser.parse_args()
 
-el_start =  16.
+el_start = 16.
 el_end = el_start + opts.elevation_range
 scan_spacing = opts.scan_spacing
 num_scans = int((el_end - el_start) / scan_spacing)
@@ -49,17 +50,19 @@ with verify_and_connect(opts) as kat:
         session.capture_start()
         # First Half
         start_time = time.time()
-        azimuth_angle = abs(-90.0 - 270.0) / 4. # should be 90 deg.
+        azimuth_angle = abs(-90.0 - 270.0) / 4.  # should be 90 deg.
         target1 = 'azel, %f, %f' % (-90. + azimuth_angle, (el_end + el_start) / 2.)
         session.label('raster')
-        session.raster_scan(target1, num_scans=num_scans, scan_duration=scan_duration, scan_extent=scan_extent,
-                            scan_spacing=scan_spacing, scan_in_azimuth=True, projection='plate-carree')
+        session.raster_scan(target1, num_scans=num_scans, scan_duration=scan_duration,
+                            scan_extent=scan_extent, scan_spacing=scan_spacing,
+                            scan_in_azimuth=True, projection='plate-carree')
         user_logger.info("Observed horizon part 1/2 for %d seconds" % (time.time() - start_time))
         # Second Half
         half_time = time.time()
         target2 = 'azel, %f, %f' % (-90. + azimuth_angle * 3., (el_end + el_start) / 2.)
         session.label('raster')
-        session.raster_scan(target2, num_scans=num_scans, scan_duration=scan_duration, scan_extent=scan_extent,
-                            scan_spacing=scan_spacing, scan_in_azimuth=True, projection='plate-carree')
+        session.raster_scan(target2, num_scans=num_scans, scan_duration=scan_duration,
+                            scan_extent=scan_extent, scan_spacing=scan_spacing,
+                            scan_in_azimuth=True, projection='plate-carree')
         user_logger.info("Observed horizon part 2/2 for %d Seconds (%d Seconds in Total)" %
                          ((time.time() - half_time), (time.time() - start_time)))

--- a/observation/horizon_mask_scan.py
+++ b/observation/horizon_mask_scan.py
@@ -16,12 +16,6 @@ parser.add_option('--elevation-range', dest='elevation_range', type="float", def
                        "elevation (default=%default)")
 parser.add_option('--scan-spacing', dest='scan_spacing', type="float", default=1.0,
                   help="The spacing of the scan lines in the experiment, in degrees (default=%default)")
-parser.add_option('--reset-gain', type='int', default=None,
-                  help='Value for the reset of the correlator F-engine gain '
-                       '(default=%default)')
-parser.add_option('--fft-shift', type='int',
-                  help='Set correlator F-engine FFT shift (default=leave as is)')
-
 # Set default value for any option (both standard and experiment-specific options)
 parser.set_defaults(description='Horizon mask')
 # Parse the command line
@@ -37,16 +31,6 @@ scan_extent = 179.
 with verify_and_connect(opts) as kat:
     with start_session(kat, **vars(opts)) as session:
         session.standard_setup(**vars(opts))
-        if opts.reset_gain is not None:
-            if not session.cbf.fengine.inputs:
-                raise RuntimeError("Failed to get correlator input labels, "
-                                   "cannot set the F-engine gains")
-            for inp in session.cbf.fengine.inputs:
-                session.cbf.fengine.req.gain(inp, opts.reset_gain)
-                user_logger.info("F-engine %s gain set to %g",
-                                 inp, opts.reset_gain)
-        if opts.fft_shift is not None:
-            session.cbf.fengine.req.fft_shift(opts.fft_shift)
         session.capture_start()
         # First Half
         start_time = time.time()

--- a/observation/scan_gains.py
+++ b/observation/scan_gains.py
@@ -38,9 +38,9 @@ parser.set_defaults(description='Target track', nd_params='coupler,30,0,-1')
 opts, args = parser.parse_args()
 
 if len(args) == 0:
-    args.append('SCP, radec, 0, -90') 
+    args.append('SCP, radec, 0, -90')
 
-g_start,g_end,g_step =np.array(opts.gain.split(',') ).astype(float)
+g_start, g_end, g_step = np.array(opts.gain.split(',')).astype(float)
 # Check options and build KAT configuration, connecting to proxies and devices
 with verify_and_connect(opts) as kat:
     targets = collect_targets(kat, args)
@@ -66,7 +66,7 @@ with verify_and_connect(opts) as kat:
             keep_going = opts.max_duration is not None
             targets_before_loop = len(targets_observed)
             # Iterate through source list, picking the next one that is up
-            for gain in np.logspace(np.log10(g_start),np.log10(g_end),g_step):
+            for gain in np.logspace(np.log10(g_start), np.log10(g_end), g_step):
                 for target in targets.iterfilter(el_limit_deg=opts.horizon):
                     # Cut the track short if time ran out
                     duration = opts.track_duration
@@ -80,11 +80,11 @@ with verify_and_connect(opts) as kat:
                             break
                         duration = min(duration, time_left)
                     # Set the gain to a single non complex number if needed
-                    session.label('track_gain,%g,%gi'%(gain.real,gain.imag))
+                    session.label('track_gain,%g,%gi' % (gain.real, gain.imag))
                     for inp in session.cbf.fengine.inputs:
                         session.cbf.fengine.req.gain(inp, gain)
                         user_logger.info("F-engine %s gain set to %g +%gi",
-                                         inp, gain.real,gain.imag)
+                                         inp, gain.real, gain.imag)
                     if session.track(target, duration=duration):
                         targets_observed.append(target.description)
                 if keep_going and len(targets_observed) == targets_before_loop:

--- a/observation/spiral_holography_scan.py
+++ b/observation/spiral_holography_scan.py
@@ -475,10 +475,6 @@ if __name__=="__main__":
                       help='time in seconds to prepopulate buffer in advance (default=%default)')
     parser.add_option('--mirrorx', action="store_true", default=False,
                       help='Mirrors x coordinates of pattern (default=%default)')
-    parser.add_option('--fft-shift', type='int', default=None,
-                      help='Set CBF fft shift (default=%default)')
-    parser.add_option('--default-gain', type='float', default=None,
-                      help='Set CBF gain (default=%default)')
     parser.add_option('--auto-delay', type='string', default=None,
                       help='Set CBF auto-delay on or off (default=%default)')
     parser.add_option('--debugtrack', action="store_true", default=False,
@@ -535,18 +531,10 @@ if __name__=="__main__":
             if len(targets) == 0:
                 raise ValueError("Please specify a target argument via name ('Ori A'), "
                                  "description ('azel, 20, 30') or catalogue file name ('sources.csv')")
-            # Initialise a capturing session (which typically opens an HDF5 file)
+            # Initialise a capturing session
             with start_session(kat, **vars(opts)) as session:
                 # Use the command-line options to set up the system
                 session.standard_setup(**vars(opts))
-                #set up CBF if necessary
-                if opts.fft_shift is not None:
-                    user_logger.info("Setting CBF fft-shift to %d", opts.fft_shift)
-                    session.cbf.fengine.req.fft_shift(opts.fft_shift)
-                if opts.default_gain is not None:
-                    user_logger.info("Setting CBF gains to %f", opts.default_gain)
-                    for inp in session.cbf.fengine.inputs:
-                        session.cbf.fengine.req.gain(inp, opts.default_gain)
                 #determine scan antennas
                 all_ants = session.ants
                 session.obs_params['num_scans'] = len(compositex)


### PR DESCRIPTION
Narrowband is now supported in `CaptureSession` in the pending PR ska-sa/katcorelib#334. It involves accessing F-engines and correlators per instrument and not just globally.

Many observation scripts still assume a single F-engine or correlator and is therefore not ready for narrowband. The easiest solution is to strip away all F-engine usage, since most scripts should not need it. Feel free to convince me otherwise 😄. This PR therefore gets rid of gain and FFT shift settings where possible, since those will be set by the initial `calibrate_delays` run. Those that still need it should call the session version instead of directly accessing F-engines.

The current default session behaviour is to set gains and shifts on the "wide" instrument only. We should revisit this at some point.

This addresses JIRA ticket [SR-1841](https://skaafrica.atlassian.net/browse/SR-1841).