### PR TITLE
Customized track.py which tracks the moon as a calibrator

### DIFF
--- a/holography/interferometric_raster_track.py
+++ b/holography/interferometric_raster_track.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+# Track target(s) for a specified time.
+
+import time
+import numpy as np
+
+from katcorelib import (standard_script_options, verify_and_connect,
+                        collect_targets, start_session, user_logger)
+
+import katpoint
+import ephem
+import datetime
+
+class NoTargetsUpError(Exception):
+    """No targets are above the horizon at the start of the observation."""
+
+
+# Set up standard script options
+usage = "%prog [options] <'target/catalogue'> [<'target/catalogue'> ...]"
+description = 'Track one or more sources for a specified time. At least one ' \
+              'target must be specified. Note also some **required** options below.'
+parser = standard_script_options(usage=usage, description=description)
+# Add experiment-specific options
+parser.add_option('--track-duration', type='float', default=60.0,
+                  help='Length of time to track each source, in seconds '
+                       '(default=%default)')
+parser.add_option('--max-duration', type='float', default=None,
+                  help='Maximum duration of the script in seconds, after which '
+                       'script will end as soon as the current track finishes '
+                       '(no limit by default)')
+parser.add_option('--cal-duration', type='float', default=180.0,
+                  help='Minimum duration to track bandpass calibrator per visit, in seconds '
+                       '(default="%default")')
+parser.add_option('--cal-interval', type='float', default=3600.0,
+                  help='Minimum interval between calibrator visits, in seconds '
+                       '(visits each source in turn by default)')
+parser.add_option('--repeat', action="store_true", default=False,
+                  help='Repeatedly loop through the targets until maximum '
+                       'duration (which must be set for this)')
+parser.add_option('--reset-gain', type='int', default=None,
+                  help='Value for the reset of the correlator F-engine gain '
+                       '(default=%default)')
+parser.add_option('--fft-shift', type='int',
+                  help='Set correlator F-engine FFT shift (default=leave as is)')
+parser.add_option('--moon-snapshot-duration', type='float', default=16.0,
+                  help="Lunar snapshot time in seconds. The snapshot ra/dec is "
+                  "centred at the mid-point of the snapshot timespan.")
+parser.add_option('--moon-nsnapshots-per-track', type='int', default=19,
+                  help="Number of lunar snapshots to take during lunar track")
+parser.add_option('--moon-repeat', type="float", default=20*60.0,
+                  help="Repeat lunar observation every specified seconds")
+
+# Set default value for any option (both standard and experiment-specific options)
+parser.set_defaults(description='Target track', nd_params='off')
+# Parse the command line
+opts, args = parser.parse_args()
+
+if len(args) == 0:
+    raise ValueError("Please specify at least one target argument via name "
+                     "('Cygnus A'), description ('azel, 20, 30') or catalogue "
+                     "file name ('sources.csv')")
+
+# Check options and build KAT configuration, connecting to proxies and devices
+with verify_and_connect(opts) as kat:
+    targets = collect_targets(kat, args)
+    user_logger.info("Transfer targets are [%s]",
+                     ', '.join([repr(target.name) for target in targets.filter(['~bpcal', '~gaincal'])]))
+    user_logger.info("Bandpass calibrators are [%s]",
+                     ', '.join([repr(bpcal.name) for bpcal in targets.filter('bpcal')]))
+    user_logger.info("Polarization calibrators are [%s]",
+                     ', '.join([repr(polcal.name) for polcal in targets.filter('polcal')]))
+
+    # Start capture session, which creates HDF5 file
+    with start_session(kat, **vars(opts)) as session:
+        # Quit early if there are no sources to observe
+        if len(targets.filter(el_limit_deg=opts.horizon)) == 0:
+            raise NoTargetsUpError("No targets are currently visible - "
+                                   "please re-run the script later")
+        # Set the gain to a single non complex number if needed
+        if opts.reset_gain is not None:
+            if not session.cbf.fengine.inputs:
+                raise RuntimeError("Failed to get correlator input labels, "
+                                   "cannot set the F-engine gains")
+            for inp in session.cbf.fengine.inputs:
+                session.cbf.fengine.req.gain(inp, opts.reset_gain)
+                user_logger.info("F-engine %s gain set to %g",
+                                 inp, opts.reset_gain)
+
+        session.standard_setup(**vars(opts))
+        if opts.fft_shift is not None:
+            session.cbf.fengine.req.fft_shift(opts.fft_shift)
+        session.capture_start()
+
+        start_time = time.time()
+
+        targets_observed = []
+        # Keep going until the time is up
+        target_total_duration = [0.0] * len(targets)
+        keep_going = True
+        
+        last_lunar_scan = -np.inf
+        last_cal_visit = -np.inf
+        while keep_going:
+            keep_going = (opts.max_duration is not None) and opts.repeat
+            targets_before_loop = len(targets_observed)
+            # Iterate through source list, picking the next one that is up
+            target_list = list(targets.filter(['~bpcal', '~gaincal']))
+            n = 0
+            while n < len(target_list):
+                # Cut the track short if time ran out
+                def _time_left(opts, start_time, track_duration):
+                    """ compute duration based on time remaining """
+                    if track_duration is not None:
+                        time_left = opts.max_duration - (time.time() - start_time)
+                        if time_left <= 0.:
+                            user_logger.warning("Maximum duration of %g seconds "
+                                                "has elapsed - stopping script",
+                                                opts.max_duration)
+                            return 0, False
+                        duration = min(track_duration, time_left)
+                        return duration, True
+
+                def _go_observe(session, target, targets_observed, target_total_duration, duration):
+                    session.label('track')
+                    if session.track(target, duration=duration):
+                        targets_observed.append(target.description)
+                        target_total_duration[n] += duration
+                # select between calibrator, moon or target
+                if time.time() - last_lunar_scan > opts.moon_repeat:
+                    # time to observe moon
+                    last_lunar_scan = time.time()
+                    for lunar_track in range(opts.moon_nsnapshots_per_track):
+                        duration, keep_going = _time_left(opts, start_time, opts.moon_snapshot_duration)
+                        if not keep_going: 
+                            #user_logger.info("DEBUG: Out of time. Stopping")
+                            break
+                        observer = ephem.Observer()
+                        observer.lon='21:24:38.5'
+                        observer.lat='-30:43:17.3'
+                        observer.elevation = 1038.0
+                        # ra, dec to be computed based on the centre of the snapshot
+                        # it is up to the observer to pick sensible uv cuts to ensure
+                        # moon does not move more than a fractional synthesized beam width
+                        dt = datetime.datetime.utcfromtimestamp(time.time() + duration / 2.0)
+                        observer.date = str(dt)
+                        #user_logger.info("DEBUG: Setting lunar ephemaris to {}".format(observer.date))
+                        moon = ephem.Moon(observer)
+                        moon.compute(observer)
+                        target = katpoint.construct_radec_target(moon.ra, moon.dec)
+                        session.label('track')
+                        user_logger.info("Initiating %g-second Lunar snapshot (%d/%d) (%.2f, %.2f)" % 
+                                        (duration, 
+                                        lunar_track + 1,
+                                        opts.moon_nsnapshots_per_track,
+                                        katpoint.rad2deg(float(moon.ra)), 
+                                        katpoint.rad2deg(float(moon.dec)),))
+                        _go_observe(session, target, targets_observed, target_total_duration, duration)
+                    if not keep_going: 
+                        #user_logger.info("DEBUG: Out of time. Stopping")
+                        break
+                elif time.time() - last_cal_visit > opts.cal_interval:
+                    # time to observe calibrators
+                    last_cal_visit = time.time()
+                    for t in list(targets.filter('bpcal')) + list(targets.filter('polcal')):
+                        duration, keep_going = _time_left(opts, start_time, opts.cal_duration)    
+                        if not keep_going: 
+                            #user_logger.info("DEBUG: Out of time. Stopping")
+                            break
+                        _go_observe(session, t, targets_observed, target_total_duration, duration)
+                else:
+                    # select next raster target
+                    duration, keep_going = _time_left(opts, start_time, opts.track_duration)
+                    if not keep_going: 
+                        #user_logger.info("DEBUG: Out of time. Stopping")
+                        break
+                    target = target_list[n]
+                    _go_observe(session, target, targets_observed, target_total_duration, duration)
+                n += 1 # next target
+
+            if keep_going and len(targets_observed) == targets_before_loop:
+                user_logger.warning("No targets are currently visible - "
+                                    "stopping script instead of hanging around")
+                keep_going = False
+        user_logger.info("Targets observed : %d (%d unique)",
+                         len(targets_observed), len(set(targets_observed)))
+        # print out a sorted list of target durations
+        ind = np.argsort(target_total_duration)
+        for i in reversed(ind):
+            user_logger.info('Source %s observed for %.2f hrs',
+                             targets.targets[i].description, target_total_duration[i] / 3600.0)

--- a/holography/interferometric_raster_track.py
+++ b/holography/interferometric_raster_track.py
@@ -175,7 +175,7 @@ with verify_and_connect(opts) as kat:
                         break
                     target = target_list[n]
                     _go_observe(session, target, targets_observed, target_total_duration, duration)
-                n += 1 # next target
+                    n += 1 # next target
 
             if keep_going and len(targets_observed) == targets_before_loop:
                 user_logger.warning("No targets are currently visible - "

--- a/unmaintained/lunar_calibrate.py
+++ b/unmaintained/lunar_calibrate.py
@@ -26,7 +26,7 @@ parser.add_option('-b', '--bpcal-duration', type='float', default=300,
 parser.add_option('-i', '--bpcal-interval', type='float',
                   help='Minimum interval between bandpass calibrator visits, in seconds '
                        '(visits each source in turn by default)')
-parser.add_option('--lunar-interval', type='float',default=1800
+parser.add_option('--lunar-interval', type='float',default=1800,
                   help='Minimum interval between Lunar calibrator visits, in seconds '
                        '(default="%default")')
 parser.add_option('-g', '--gaincal-duration', type='float', default=60,
@@ -83,9 +83,9 @@ with verify_and_connect(opts) as kat:
                 if time.time() - time_of_last_lunar_cal >= opts.lunar_interval:
                     time_of_last_lunar_cal = time.time()
                     session.label('Moon')
-                        track_status = session.track(katpoint.Target('Moon,special'), duration=duration['bpcal'])
-                        if track_status:
-                            source_total_duration[katpoint.Target('Moon,special')] += duration['bpcal']
+                    track_status = session.track(katpoint.Target('Moon,special'), duration=duration['bpcal'])
+                    if track_status:
+                        source_total_duration[katpoint.Target('Moon,special')] += duration['bpcal']
                 # Visit source if it is not a bandpass calibrator
                 # (or bandpass calibrators are not treated specially)
                 # If there are no targets specified, assume the calibrators are the targets, else

--- a/unmaintained/lunar_calibrate.py
+++ b/unmaintained/lunar_calibrate.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+# Track target and calibrators for imaging.
+
+import time
+from collections import defaultdict
+
+from katcorelib import (standard_script_options, verify_and_connect,
+                        collect_targets, start_session, user_logger)
+
+
+# Set up standard script options
+description = "Perform an imaging run of a specified target, visiting the " \
+              "bandpass and gain calibrators along the way. The calibrators " \
+              "are identified by tags in their description strings ('bpcal' " \
+              "and 'gaincal', respectively), while the imaging targets may " \
+              "optionally have a tag of 'target'."
+parser = standard_script_options(usage="%prog [options] <'target/catalogue'> [<'target/catalogue'> ...]",
+                                 description=description)
+# Add experiment-specific options
+parser.add_option('-t', '--target-duration', type='float', default=300,
+                  help='Minimum duration to track the imaging target per visit, in seconds '
+                       '(default="%default")')
+parser.add_option('-b', '--bpcal-duration', type='float', default=300,
+                  help='Minimum duration to track bandpass calibrator per visit, in seconds '
+                       '(default="%default")')
+parser.add_option('-i', '--bpcal-interval', type='float',
+                  help='Minimum interval between bandpass calibrator visits, in seconds '
+                       '(visits each source in turn by default)')
+parser.add_option('-g', '--gaincal-duration', type='float', default=60,
+                  help='Minimum duration to track gain calibrator per visit, in seconds '
+                       '(default="%default")')
+parser.add_option('-m', '--max-duration', type='float',
+                  help='Maximum duration of script, in seconds '
+                       '(the default is to keep observing until all sources have set)')
+# Set default value for any option (both standard and experiment-specific options)
+# parser.set_defaults(description='Imaging run', nd_params='coupler,0,0,-1', dump_rate=0.1)
+parser.set_defaults(description='Imaging run', nd_params='off')
+# Parse the command line
+opts, args = parser.parse_args()
+
+# Check options and arguments, and build KAT configuration, connecting to proxies and devices
+if len(args) == 0:
+    raise ValueError("Please specify the target(s) and calibrator(s) to observe as arguments, either as "
+                     "description strings or catalogue filenames")
+
+with verify_and_connect(opts) as kat:
+    sources = collect_targets(kat, args)
+
+    user_logger.info("Imaging targets are [%s]",
+                     ', '.join([repr(target.name) for target in sources.filter(['~bpcal', '~gaincal'])]))
+    user_logger.info("Bandpass calibrators are [%s]",
+                     ', '.join([repr(bpcal.name) for bpcal in sources.filter('bpcal')]))
+    user_logger.info("Gain calibrators are [%s]",
+                     ', '.join([repr(gaincal.name) for gaincal in sources.filter('gaincal')]))
+    duration = {'target': opts.target_duration, 'bpcal': opts.bpcal_duration,
+                'gaincal': opts.gaincal_duration}
+
+    with start_session(kat, **vars(opts)) as session:
+        session.standard_setup(**vars(opts))
+        session.capture_start()
+
+        start_time = time.time()
+        # If bandpass interval is specified, force the first visit to be to the bandpass calibrator(s)
+        time_of_last_bpcal = 0
+        loop = True
+        source_total_duration = defaultdict(float)
+        
+        while loop:
+            # Loop over sources in catalogue in sequence
+            source_observed = defaultdict(bool)
+            for source in sources:
+                # If it is time for a bandpass calibrator to be visited on an interval basis, do so
+                if opts.bpcal_interval is not None and time.time() - time_of_last_bpcal >= opts.bpcal_interval:
+                    time_of_last_bpcal = time.time()
+                    for bpcal in sources.filter('bpcal'):
+                        session.label('track')
+                        track_status = session.track(bpcal, duration=duration['bpcal'])
+                        
+                        if track_status:
+                            source_total_duration[bpcal] += duration['bpcal']
+                # Visit source if it is not a bandpass calibrator
+                # (or bandpass calibrators are not treated specially)
+                # If there are no targets specified, assume the calibrators are the targets, else
+                targets = [target for target in sources.filter(['~bpcal', '~gaincal'])]
+                if opts.bpcal_interval is None or 'bpcal' not in source.tags or not targets:
+                    # Set the default track duration for a target with no recognised tags
+                    track_duration = opts.target_duration
+                    for tag in source.tags:
+                        track_duration = duration.get(tag, track_duration)
+                    session.label('track')
+                    track_status = source_observed[source] = session.track(source, duration=track_duration)
+                    
+                    if track_status:
+                        source_total_duration[source] += track_duration
+                        
+                if opts.max_duration and time.time() > start_time + opts.max_duration:
+                    user_logger.info('Maximum script duration (%d s) exceeded, stopping script',
+                                     opts.max_duration)
+                    loop = False
+                    break
+            if loop and not any(source_observed.values()):
+                user_logger.warning('All imaging targets and gain cals are '
+                                    'currently below horizon, stopping script')
+                loop = False
+        for source in sources:
+            user_logger.info('Source %s observed for %.2f hrs',
+                             source.description, source_total_duration[source] / 3600.0)


### PR DESCRIPTION
This track.py fulfils the most basic requirements of proposal: https://docs.google.com/document/d/1Pc-egnPTpsZk-ze4N0rP14j1k1GebB3kply05tFrwe4/edit?usp=sharing

It switches between calibrators, the moon and a raster at intervals similar to image.py. The periodic lunar tracks are decomposed into snapshots with RADEC computed at the centre of the snapshot timespan.

Tapering the long spacings we should be able to calibrate scans up to 2 minutes in duration, although I'm tracking the moon on shorter intervals here by default.
```
DRY-RUN: 2019-11-25 06:59:59.999Z INFO     Switching off all noise diodes
DRY-RUN: 2019-11-25 06:59:59.999Z INFO     Noise diode will not fire automatically while performing canned commands
DRY-RUN: 2019-11-25 06:59:59.999Z INFO     Stopping / readying antennas
DRY-RUN: 2019-11-25 06:59:59.999Z INFO     INIT
DRY-RUN: 2019-11-25 06:59:59.999Z INFO     Capture block ID = 20191118-0002-1234567890
DRY-RUN: 2019-11-25 06:59:59.999Z INFO     --------------------------
DRY-RUN: 2019-11-25 06:59:59.999Z INFO     New compound scan: 'track'
DRY-RUN: 2019-11-25 06:59:59.999Z INFO     Initiating 16-second Lunar snapshot (1/19) (224.33, -12.01)
DRY-RUN: 2019-11-25 06:59:59.999Z INFO     New compound scan: 'track'
DRY-RUN: 2019-11-25 06:59:59.999Z INFO     Initiating 16-second track on target 'Ra: 14:57:19.87 Dec: -12:00:25.3'
DRY-RUN: 2019-11-25 06:59:59.999Z INFO     slewing to target
DRY-RUN: 2019-11-25 07:00:56.105Z INFO     target reached
DRY-RUN: 2019-11-25 07:00:56.105Z INFO     tracking target
DRY-RUN: 2019-11-25 07:01:13.105Z INFO     target tracked for 16 seconds
DRY-RUN: 2019-11-25 07:01:13.105Z INFO     New compound scan: 'track'
DRY-RUN: 2019-11-25 07:01:13.105Z INFO     Initiating 16-second Lunar snapshot (2/19) (224.34, -12.01)
DRY-RUN: 2019-11-25 07:01:13.105Z INFO     New compound scan: 'track'
DRY-RUN: 2019-11-25 07:01:13.105Z INFO     Initiating 16-second track on target 'Ra: 14:57:21.78 Dec: -12:00:42.1'
DRY-RUN: 2019-11-25 07:01:13.105Z INFO     slewing to target
DRY-RUN: 2019-11-25 07:01:14.110Z INFO     target reached
DRY-RUN: 2019-11-25 07:01:14.110Z INFO     tracking target
```