### PR TITLE
Add windstow check to AP endurance script

### DIFF
--- a/AR1/drive_antennas/AP_endurance.py
+++ b/AR1/drive_antennas/AP_endurance.py
@@ -216,7 +216,7 @@ def exercise_antenna(ant, taz, tel, exercise_indexer, total=1, dry_run=False):
                     # If windstow is active, break here before next ridx position and wait for
                     # wind to subside in the az/el loop. Proxy should be able to interrupt motion
                     # if there is an active indexer movement underway.
-                    if ant.sensor.windstow_active.get_value()
+                    if ant.sensor.windstow_active.get_value():
                         break
 
                     ridx_movement_start_time = time.time()


### PR DESCRIPTION
This PR is to add a windstow check to the endurance script. To avoid the effect of pointing models affecting the antenna positioning, this script interacts with the AP directly. This however means that it bypasses the usual protections that the receptor proxy provides for requests while a windstow is active.
This is an interim solution until a more comprehensive option can be developed.