### PR TITLE
Fix tippingcurve s band

### DIFF
--- a/RTS/2.1-Tipping_Curve/red_tipping_curve.py
+++ b/RTS/2.1-Tipping_Curve/red_tipping_curve.py
@@ -630,7 +630,7 @@ freq_chans = opts.freq_chans
 for ant in h5.ants:
     #Load the data file
     rec = h5.receivers[ant.name]
-    nice_filename =  args[0].split('/')[-1]+ '_' +ant.name+'_tipping_curve'
+    nice_filename =  args[0].split('/')[-1].split('?')[0]  + '_' +ant.name+'_tipping_curve'
     pp =PdfPages(nice_filename+'.pdf')
     nice_title = " %s  Ant=%s"%(args[0].split('/')[-1], ant.name)
 

--- a/RTS/2.5-Gain_Stability/gain_stability.py
+++ b/RTS/2.5-Gain_Stability/gain_stability.py
@@ -182,7 +182,7 @@ for ant_obj in h5.ants :
     gain_vv = np.array(())
     timestamps = np.array(())
     filename = args[0]
-    nice_filename =  filename.split('/')[-1]+ '_' +ant+'_gain_stability'
+    nice_filename =  filename.split('/')[-1].split('?')[0]+ '_' +ant+'_gain_stability'
     pp = PdfPages(nice_filename+'.pdf')
 
     filename = args[0]

--- a/RTS/2.7-Pointing/jitter_pointing.py
+++ b/RTS/2.7-Pointing/jitter_pointing.py
@@ -104,7 +104,7 @@ else:
     ant_list = [opts.ant]
 
 for ant in ant_list :
-    nice_filename =  args[0].split('/')[-1]+ '_' +ant+'_jitter_test'
+    nice_filename =  args[0].split('/')[-1].split('?')[0]+ '_' +ant+'_jitter_test'
     pp = PdfPages(nice_filename+'.pdf')
 
     h5.select(scans='track',ants=ant,channels= ~rfi_static_flags)

--- a/RTS/2.7-Pointing/pointing_stats.py
+++ b/RTS/2.7-Pointing/pointing_stats.py
@@ -351,7 +351,7 @@ for line in text: print(line)
 ###################################
 # Plot pointing model comparison.
 ##################################
-nice_filename =  args[0].split('/')[-1]+ '_pointing_stats'
+nice_filename =  args[0].split('/')[-1].split('?')[0]+ '_pointing_stats'
 pp = PdfPages(nice_filename+'.pdf')
 
 if opts.compare:

--- a/RTS/2.7-Pointing/residual_pointing_offset.py
+++ b/RTS/2.7-Pointing/residual_pointing_offset.py
@@ -471,7 +471,7 @@ textString.append("")
 textString.append(git_info() )
 #for line in textString: print line
 if not opts.no_plot :
-    nice_filename =  args[0].split('/')[-1]+ '_residual_pointing_offset'
+    nice_filename =  args[0].split('/')[-1].split('?')[0]+ '_residual_pointing_offset'
     if len(args) > 1 : nice_filename =  args[0].split('/')[-1]+'_Multiple_files' + '_residual_pointing_offset'
     pp = PdfPages(nice_filename+'.pdf')
 


### PR DESCRIPTION
This is a fix to a few scripts so that they can work when a url is provided to them as a file name.
The problem was that the ?token=...  part of the url was messing up the output filename choice . this is fixed by only selecting text between the last '/' and the '?'  