### PR TITLE
Remove katcp from dependancy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,4 +40,4 @@ setup(name="katsdpscripts",
       package_data={'': ['RTS/gsm/gsm.f']},
       setup_requires=['katversion', good_numpy],
       use_katversion=True,
-      install_requires=['numpy', 'katpoint', 'katcp', 'scikits.fitting', 'futures', 'six'])
+      install_requires=['numpy', 'katpoint',  'scikits.fitting', 'futures', 'six'])


### PR DESCRIPTION
This is a problem because the reduction scripts which don't use katcp are python3 and katcp is python 2.7