### PR TITLE
Updated track_scan_drift.py to cycle ND while tracking the target

### DIFF
--- a/AR1/utility/track_scan_drift.py
+++ b/AR1/utility/track_scan_drift.py
@@ -70,6 +70,7 @@ with verify_and_connect(opts) as kat:
             start_time = time.time()
             target =observation_sources.filter(el_limit_deg=[opts.horizon, opts.max_elevation]).targets[0]
 
+            session.track(target, duration=0) # Start tracking the target, so that it's stable during ND cycle
             session.label('noise diode')
             session.fire_noise_diode('coupler', on=10, off=10)
 
@@ -112,5 +113,6 @@ with verify_and_connect(opts) as kat:
                 session.track(target, duration=opts.track_duration)
             time.sleep(10)
 
+            session.track(target, duration=0) # Start tracking the target, so that it's stable during ND cycle
             session.label('noise diode')
             session.fire_noise_diode('coupler', on=10, off=10)


### PR DESCRIPTION
the original code had the first ND cycle happen with the antennas in STOP mode, while the second happened with the antennas tracking the target.

the consequence is that the ND_ON-ND_OFF data from the first cycle was contaminated by the target (and the rest of the sky) drifting through the sidelobes. this is especially significant for typical targets observed in "single dish mode".

i have added session.track() instructions before each of the explicitly coded (first and last) ND cycles to now guarantee that the antennas are tracking the target while the ND is cycled.