### PR TITLE
Adjust max gap

### DIFF
--- a/observation/bf_phaseup.py
+++ b/observation/bf_phaseup.py
@@ -114,6 +114,8 @@ parser.add_option('--reconfigure-sdp', action="store_true", default=False,
 # Set default value for any option (both standard and experiment-specific options)
 parser.set_defaults(observer='comm_test', nd_params='off', project_id='COMMTEST',
                     description='Phase-up observation that sets F-engine gains')
+parser.add_option('--max_gap_MHz', type='float', default=64.0,
+                  help='Override max_gap_MHz (default=%default)')
 # Parse the command line
 opts, args = parser.parse_args()
 
@@ -162,7 +164,7 @@ with verify_and_connect(opts) as kat:
         bp_gains = session.get_cal_solutions('B')
         delays = session.get_cal_solutions('K')
         cal_channel_freqs = session.get_cal_channel_freqs()
-        bp_gains = clean_bandpass(bp_gains, cal_channel_freqs, max_gap_Hz=256e6)
+        bp_gains = clean_bandpass(bp_gains, cal_channel_freqs, max_gap_Hz=opts.max_gap_MHz)
 
         if opts.random_phase:
             user_logger.warning("Setting F-engine gains with random phases "

--- a/observation/bf_phaseup.py
+++ b/observation/bf_phaseup.py
@@ -111,11 +111,12 @@ parser.add_option('--random-phase', action='store_true', default=False,
                   help='Apply random phases in F-engine (incoherent beamformer)')
 parser.add_option('--reconfigure-sdp', action="store_true", default=False,
                   help='Reconfigure SDP subsystem at the start to clear crashed containers')
+parser.add_option('--max-gap-MHz', type='float', default=64.0,
+                  help='The maximum gap in the bandpass gain that will still be interpolated across, in MHz'
+                  '(default = %default)')
 # Set default value for any option (both standard and experiment-specific options)
 parser.set_defaults(observer='comm_test', nd_params='off', project_id='COMMTEST',
                     description='Phase-up observation that sets F-engine gains')
-parser.add_option('--max_gap_MHz', type='float', default=64.0,
-                  help='Override max_gap_MHz (default=%default)')
 # Parse the command line
 opts, args = parser.parse_args()
 

--- a/observation/bf_phaseup.py
+++ b/observation/bf_phaseup.py
@@ -162,7 +162,7 @@ with verify_and_connect(opts) as kat:
         bp_gains = session.get_cal_solutions('B')
         delays = session.get_cal_solutions('K')
         cal_channel_freqs = session.get_cal_channel_freqs()
-        bp_gains = clean_bandpass(bp_gains, cal_channel_freqs, max_gap_Hz=64e6)
+        bp_gains = clean_bandpass(bp_gains, cal_channel_freqs, max_gap_Hz=256e6)
 
         if opts.random_phase:
             user_logger.warning("Setting F-engine gains with random phases "

--- a/observation/bf_phaseup.py
+++ b/observation/bf_phaseup.py
@@ -164,7 +164,7 @@ with verify_and_connect(opts) as kat:
         bp_gains = session.get_cal_solutions('B')
         delays = session.get_cal_solutions('K')
         cal_channel_freqs = session.get_cal_channel_freqs()
-        bp_gains = clean_bandpass(bp_gains, cal_channel_freqs, max_gap_Hz=opts.max_gap_MHz)
+        bp_gains = clean_bandpass(bp_gains, cal_channel_freqs, max_gap_Hz=opts.max_gap_MHz*1e6)
 
         if opts.random_phase:
             user_logger.warning("Setting F-engine gains with random phases "


### PR DESCRIPTION
Add the max-gap-MHz in clean_bandpass as a parameter to the script.

This is the maximum gap in the bandpass gain that will still be interpolated across, in MHz