### PR TITLE
Only add targets_observed if scan was completed

### DIFF
--- a/RTS/2.4-Gain_Curve/point_source_scan.py
+++ b/RTS/2.4-Gain_Curve/point_source_scan.py
@@ -143,9 +143,9 @@ with verify_and_connect(opts) as kat:
                     kwargs = styles[style]
                     # Get rid of keyword arguments that are not meant for session.raster_scan
                     kwargs.pop('dump_rate', None)
-                    session.raster_scan(target, scan_in_azimuth=not opts.scan_in_elevation,
-                                        projection=opts.projection, **kwargs)
-                    targets_observed.append(target.name)
+                    if session.raster_scan(target, scan_in_azimuth=not opts.scan_in_elevation,
+                                           projection=opts.projection, **kwargs):
+                        targets_observed.append(target.name)
                     skip_file.write(target.description + "\n")
                     # The default is to do only one iteration through source list
                     if opts.min_time <= 0.0:

--- a/RTS/2.4-Gain_Curve/point_source_scan.py
+++ b/RTS/2.4-Gain_Curve/point_source_scan.py
@@ -146,7 +146,7 @@ with verify_and_connect(opts) as kat:
                     if session.raster_scan(target, scan_in_azimuth=not opts.scan_in_elevation,
                                            projection=opts.projection, **kwargs):
                         targets_observed.append(target.name)
-                    skip_file.write(target.description + "\n")
+                        skip_file.write(target.description + "\n")
                     # The default is to do only one iteration through source list
                     if opts.min_time <= 0.0:
                         keep_going = False


### PR DESCRIPTION
session.raster_scan() returns False if the scan was not completed (source below horizon or other fault) - but that feedback has been ignored till now. With this change, only if the scan was successfully completed is the target added to the list of "targets_observed".