### PR TITLE
Elevation limits & dwell time now configurable

### DIFF
--- a/RTS/2.1-Tipping_Curve/obs_tipping_curve.py
+++ b/RTS/2.1-Tipping_Curve/obs_tipping_curve.py
@@ -13,35 +13,45 @@ parser = standard_script_options(usage="%prog [options]",
                                               Or Select a Satilite clear Azimith,\
                                               Some options are **required**.")
 # Add experiment-specific options
+parser.add_option('--el-limits', type="string", default="15,90",
+                  help='"Minimum, maximum" elevation angles for the tipping curve, in degrees (default="%default")')
 parser.add_option('-z', '--az', type="float", default=None,
                   help='Azimuth angle along which to do tipping curve, in degrees (default="%default")')
 parser.add_option('--spacing', type="float", default=1.0,
                   help='The Spacing along the elevation axis of the tipping curve that measuremnts are taken, in degrees (default="%default")')
+parser.add_option('-t', '--dwell-time', type="float", default=30,
+                  help='Total dwell time per elevation step, with ND on for 1/3rd of the time (default="%default")')
 parser.add_option( '--tip-both-directions', action="store_true" , default=False,
                   help='Do tipping curve from low to high elevation and then from high to low elevation')
 
 # Set default value for any option (both standard and experiment-specific options)
-parser.set_defaults(description='Tipping Curve')
+parser.set_defaults(description='Tipping Curve', nd_params='off')
 
 # Parse the command line
 opts, args = parser.parse_args()
 
-on_time = 15.0
+el_lim = [float(e) for e in opts.el_limits.split(",")]
+on_time = opts.dwell_time/3.
+nd_period = on_time*2
+
 with verify_and_connect(opts) as kat:
+    # Iterate through elevation angles
+    spacings = list(np.arange(el_lim[0],el_lim[1]+0.1,opts.spacing))
+    if opts.tip_both_directions :
+        spacings += list(np.arange(el_lim[1],el_lim[0]-0.1,-opts.spacing))
     # Ensure that azimuth is in valid physical range of -185 to 275 degrees
     if opts.az is None:
         user_logger.info("No Azimuth selected , selecting clear Azimuth")
         if not kat.dry_run:
-            timestamp = [katpoint.Timestamp(time.time()+i) for i in ((np.arange(15.0,90.1,opts.spacing)-15.0)*(on_time+20.0+1.0))]
+            timestamp = [katpoint.Timestamp(time.time()+i) for i in (np.arange(len(spacings))*(on_time+nd_period+1.0))]
             #timestamps calculated as  number of pointings times the length of each pointing added to time.now()
-            #each pointing is on_time + 20s noisdiode + 1 second slew. 
             #load the standard KAT sources ... similar to the SkyPlot of the katgui
             observation_sources = kat.sources.filter(tags=['~Pulsars'])
             source_az = []
             for source in observation_sources.targets:
                 az, el = np.degrees(source.azel(timestamp=timestamp))   # was rad2deg
                 az[az > 180] = az[az > 180] - 360
-                source_az += list(set(az[el > 15]))
+                source_az += list(set(az[el > el_lim[0]]))
             source_az.sort()
             gap = np.diff(source_az).argmax()+1
             opts.az = (source_az[gap] + source_az[gap+1]) /2.0
@@ -58,11 +68,7 @@ with verify_and_connect(opts) as kat:
     with start_session(kat, **vars(opts)) as session:
         session.standard_setup(**vars(opts))
         session.capture_start()
-        # Iterate through elevation angles
-        spacings = list(np.arange(15.0,90.1,opts.spacing))
-        if opts.tip_both_directions :
-            spacings += list(np.arange(90.0,19.9,-opts.spacing))
         for el in spacings:
             session.label('track')
             session.track('azel, %f, %f' % (opts.az, el), duration=on_time)
-            session.fire_noise_diode('coupler', on=10, off=10)
+            session.fire_noise_diode('coupler', on=nd_period/2., off=nd_period/2.)


### PR DESCRIPTION
1) Added --el-limits & --dwell-time arguments to override defaults from command line.
2) Set nd_params default to 'off', since currently the default '10,10' is performed wherever the antenna is when the script starts before slewing to starting position, so it is completely useless and just wastes time.