### PR TITLE
Add python2.7 compatibility to check_baseline.py

### DIFF
--- a/utility/check_baseline.py
+++ b/utility/check_baseline.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import division  # Because obs & CAM uses python2
 # This script checks to see if the baseline criteria for observations is met
 
 import numpy as np


### PR DESCRIPTION
Due to the a portion of the CAM system and the obs machines using
python2.7 this script needs to function with python2.7.  The
interger-divide has been made backwards compatible.

Just a note, Python2 was "Sunset" on January 1 2020.