### PR TITLE
Add LADUMA--reduced-- to baseline script

### DIFF
--- a/utility/check_baseline.py
+++ b/utility/check_baseline.py
@@ -171,7 +171,7 @@ reduced_ants  =remove_ants(ants,missing_ants,args.verbose)
 
 
 # Minimum fraction of available baselines in the baseline_bins intervals
-ProjectConstraints = namedtuple('ProjectConstraints', 'minfrac baseline_bins mintotal,required_ants,required_ants_number')
+ProjectConstraints = namedtuple('ProjectConstraints', 'minfrac baseline_bins mintotal required_ants required_ants_number')
 # Different projects will have different contraints
 projects['MHONGOOSE'] = ProjectConstraints(
     baseline_bins=np.array([0, 50, 100, 200, 400, 1000, 3000, 6000, 9000]),
@@ -196,6 +196,15 @@ projects['LADUMA'] = ProjectConstraints(
     required_ants = ["m048","m049","m057","m058","m059","m060","m061","m062","m063"],
     required_ants_number = 8
 )
+
+projects['LADUMA --Reduced--'] = ProjectConstraints(
+    baseline_bins=None,
+    minfrac=None,
+    mintotal = 52, # Minimum number of antennas
+    required_ants = None,
+    required_ants_number = None
+)
+
 
 projects['MIGHTEE'] = ProjectConstraints(
     baseline_bins=None,


### PR DESCRIPTION
This adds the option of the reduced Laduma antenna spec of >51 Antenna
to the script which is needed 50 % of the time.