### PR TITLE
Fix error in metrics() 69 instead of 60

### DIFF
--- a/reduction/pointing_stats.py
+++ b/reduction/pointing_stats.py
@@ -46,7 +46,7 @@ def metrics(model,az,el,measured_delta_az, measured_delta_el ,std_delta_az ,std_
     residual_az = measured_delta_az - model_delta_az
     residual_el = measured_delta_el - model_delta_el
     residual_xel  = residual_az * np.cos(el)
-    abs_sky_error = rad2deg(np.sqrt(residual_xel ** 2 + residual_el ** 2)) * 69. 
+    abs_sky_error = rad2deg(np.sqrt(residual_xel ** 2 + residual_el ** 2)) * 60. 
     ###### On the calculation of all-sky RMS #####
     # Assume the el and cross-el errors have zero mean, are distributed normally, and are uncorrelated
     # They are therefore described by a 2-dimensional circular Gaussian pdf with zero mean and *per-component*


### PR DESCRIPTION
The code incorrectly used *69 instead of *60 to convert deg->arcmin.

As a consequence all of the data in <https://docs.google.com/spreadsheets/d/1cgo5JV3RWnRg9jceNRV6tsfXQtAT0P8Tr4_URc0fo4I> needs to be scaled down by a factor 60/69!