### PR TITLE
bugfix: plane_to_sphere centered on antenna, not array center

### DIFF
--- a/AR1/reduction/interferometric_pointing/analyse_interferometric_pointing.py
+++ b/AR1/reduction/interferometric_pointing/analyse_interferometric_pointing.py
@@ -142,7 +142,7 @@ def reduce_compscan_inf(h5,rfi_static_flags=None,chunks=16,return_raw=False,use_
                     #The valid fit is needed because I have no way of working out if the gain solution was ok.
                     if valid_fit and np.any(theta <= np.pi) : # Invalid fits remain nan (initialised defaults)
                         # Convert this offset back to spherical (az, el) coordinates
-                        beam_center_azel = target.plane_to_sphere(np.radians(gaussian.mean[0]), np.radians(gaussian.mean[1]), middle_time)
+                        beam_center_azel = target.plane_to_sphere(np.radians(gaussian.mean[0]), np.radians(gaussian.mean[1]), middle_time, antenna=h5.ants[ant])
                         # Now correct the measured (az, el) for refraction and then apply the old pointing model
                         # to get a "raw" measured (az, el) at the output of the pointing model
                         beam_center_azel = [beam_center_azel[0], rc.apply(beam_center_azel[1], temperature, pressure, humidity)]


### PR DESCRIPTION
the centroid is fitted in the tangent plane, then transformed back to Az,El for an observer position on the geoid. the code used to take the catalogue's default antenna for this transformation (the array reference position, as per katcorelib/conf.py#L162), now the updated code uses the individual antennas.

this bug was identified by a systematic discrepancy between the vertical from these fits (P5&P6) compared to the vertical from tiltmeter fits (AN0,-AW0). with the fix in place the discrepancy is resolved (i.e. P5,P6 match AN0,-AW0 without systematic discrepancy).

datasets used to prove this june - august 2022: 1654129975, 1654959138, 1655331990, 1656675089, 1657979631, 1659833592, 1660330234, 1660789572, 1661864701, 1662951723 (all antennas, only m002, m012, m035 were absent).