### PR TITLE
SPR1-3063: Changes to the baseline ordering to be stable and correct

### DIFF
--- a/AR1/reduction/interferometric_pointing/analyse_interferometric_pointing.py
+++ b/AR1/reduction/interferometric_pointing/analyse_interferometric_pointing.py
@@ -54,7 +54,6 @@ def reduce_compscan_inf(h5,rfi_static_flags=None,chunks=16,return_raw=False,use_
     stdv = {}
     calibrated = False # placeholder for calibration
     h5.select(compscans=compscan_index)
-    h5.select(reset='B') # Resets only pol,corrprods,ants
     active_ants = find_active_ants(h5, 0.85)    # Only those specified AND active during this compscan
     h5.select(ants=active_ants)
     antlist = [a.name for a in h5.ants]
@@ -90,7 +89,6 @@ def reduce_compscan_inf(h5,rfi_static_flags=None,chunks=16,return_raw=False,use_
         requested_azel = [requested_azel[0], rc.apply(requested_azel[1], temperature, pressure, humidity)]
         requested_azel = katpoint.rad2deg(np.array(requested_azel))
 
-   
     gaussian_centre     = np.full((chunk_size * 2, 2, len(h5.ants)), np.nan)
     gaussian_centre_std = np.full((chunk_size * 2, 2, len(h5.ants)), np.nan)
     gaussian_width      = np.full((chunk_size * 2, 2, len(h5.ants)), np.nan)
@@ -340,7 +338,6 @@ if len(opts.channel_mask)>0:
 else:
     rfi_static_flags = None
 
-antlist = [a.name for a in h5.ants]
 if opts.outfilebase is None :
     outfilebase =  "%s_%s"%(h5.name.split('/')[-1].split('.')[0], "interferometric_pointing")
 else:

--- a/AR1/reduction/interferometric_pointing/analyse_interferometric_pointing.py
+++ b/AR1/reduction/interferometric_pointing/analyse_interferometric_pointing.py
@@ -349,6 +349,7 @@ for ant in range(len(h5.ants)):
     f[name].write(', '.join(output_field_names) + '\n')
 for compscan_index  in h5.compscan_indices :
     print("Compound scan %i  "%(compscan_index) )
+    h5.select(ants=ant_list)
     offset_data = reduce_compscan_inf(h5,rfi_static_flags,chunks,use_weights=opts.use_weights,compscan_index=compscan_index,debug=opts.debug)
     if len(offset_data) > 0 : # if not an empty set
         print("Valid data obtained from the Compound scan")

--- a/AR1/reduction/interferometric_pointing/analyse_interferometric_pointing.py
+++ b/AR1/reduction/interferometric_pointing/analyse_interferometric_pointing.py
@@ -55,7 +55,7 @@ def reduce_compscan_inf(h5,rfi_static_flags=None,chunks=16,return_raw=False,use_
     calibrated = False # placeholder for calibration
     h5.select(compscans=compscan_index)
     h5.select(reset='B') # Resets only pol,corrprods,ants
-    active_ants = list(set([a.name for a in h5.ants]) & set(find_active_ants(h5, 0.85))) # Only those specified AND active during this compscan
+    active_ants = find_active_ants(h5, 0.85)    # Only those specified AND active during this compscan
     h5.select(ants=active_ants)
     antlist = [a.name for a in h5.ants]
     bls_lookup = calprocs.get_bls_lookup(antlist,h5.corr_products)

--- a/AR1/reduction/interferometric_pointing/analyse_interferometric_pointing.py
+++ b/AR1/reduction/interferometric_pointing/analyse_interferometric_pointing.py
@@ -116,7 +116,7 @@ def reduce_compscan_inf(h5,rfi_static_flags=None,chunks=16,return_raw=False,use_
         gains_p[pol] = []
         pos = []
         stdv[pol] = []
-        h5.select(pol=pol,corrprods='cross',ants=antlist,targets=[h5.catalogue.targets[TI] for TI in target_indices],compscans=compscan_index)
+        h5.select(pol=pol,corrprods='cross',ants=antlist)
         bls_lookup = calprocs.get_bls_lookup(antlist,h5.corr_products)
         for scan in h5.scans() :
             if scan[1] != 'track':               continue

--- a/AR1/reduction/interferometric_pointing/analyse_interferometric_pointing.py
+++ b/AR1/reduction/interferometric_pointing/analyse_interferometric_pointing.py
@@ -57,7 +57,6 @@ def reduce_compscan_inf(h5,rfi_static_flags=None,chunks=16,return_raw=False,use_
     active_ants = find_active_ants(h5, 0.85)    # Only those specified AND active during this compscan
     h5.select(ants=active_ants)
     antlist = [a.name for a in h5.ants]
-    bls_lookup = calprocs.get_bls_lookup(antlist,h5.corr_products)
     # Combine target indices if they refer to the same target for the purpose of this analysis
     TGT = h5.catalogue.targets[h5.target_indices[0]].description.split(",")
     def _eq_TGT_(tgt): # tgt==TGT, "tags" don't matter


### PR DESCRIPTION
The baseline ordering were being calculated in an inconsistent  way that resulted in mixing up the baselines for different antennas . This is a fix to SPR1-3063 

"Actually, we are not reading outside the array since Python / NumPy won’t allow that. What’s happening is that we are randomly associating the gains of one antenna with another.

This is due to an assumption that the order of h5.ants is the same as the active_ants list used during the selection h5.select(ants=active_ants). Instead, what’s happening is that h5.ants is derived from the labels found in h5.corr_products, which is the primary source of information. The labels are sorted and filtered to end up with a different order. The h5.ants list is sorted alphabetically while active_ants has a random order.

So the gains and beam fits happen according to active_ants but pointing models are picked - and the models are saved - in the order of h5.ants. The script picks the right data for the dish but associates the wrong pointing model and stores the beam fit under the wrong name."

