### PR TITLE
SPR1-3199 / SPP1-107: Support MK+ compatible gain setting

### DIFF
--- a/observation/basic_health.py
+++ b/observation/basic_health.py
@@ -21,7 +21,7 @@ parser = standard_script_options(usage, description)
 parser.add_option('--verify-duration', type='float', default=64.0,
                   help='Length of time to revisit source for verification, '
                        'in seconds (default=%default)')
-parser.add_option('--fengine-gain', type='int_or_default', default='default',
+parser.add_option('--fengine-gain', type='float_or_default', default='default',
                   help='Set correlator F-engine gain (average magnitude)')
 # Set default value for any option (both standard and experiment-specific options)
 parser.set_defaults(observer='basic_health', nd_params='off',

--- a/observation/bf_phaseup.py
+++ b/observation/bf_phaseup.py
@@ -101,7 +101,7 @@ parser.add_option('-t', '--track-duration', type='float', default=64.0,
 parser.add_option('--verify-duration', type='float', default=64.0,
                   help='Length of time to revisit the source for verification, '
                        'in seconds (default=%default)')
-parser.add_option('--fengine-gain', type='int_or_default', default='default',
+parser.add_option('--fengine-gain', type='float_or_default', default='default',
                   help='Set correlator F-engine gain (average magnitude)')
 parser.add_option('--fft-shift', type='int_or_default',
                   help='Override correlator F-engine FFT shift')

--- a/observation/calibrate_delays.py
+++ b/observation/calibrate_delays.py
@@ -27,7 +27,7 @@ parser.add_option('-t', '--track-duration', type='float', default=32.0,
 parser.add_option('--verify-duration', type='float', default=64.0,
                   help='Length of time to revisit the source for verification, '
                        'in seconds (default=%default)')
-parser.add_option('--fengine-gain', type='int_or_default', default='default',
+parser.add_option('--fengine-gain', type='float_or_default', default='default',
                   help='Set correlator F-engine gain')
 parser.add_option('--fft-shift', type='int_or_default', default='default',
                   help='Set correlator F-engine FFT shift')


### PR DESCRIPTION
The new `float_or_default` script option type supports gain setting on both MK (via an undocumented feature) and MK+ correlators. We just treat all gains as floats instead of the purported ints in the original MK ICD.

This depends on ska-sa/katcorelib#392 being released to site.